### PR TITLE
removing duplicative faction code

### DIFF
--- a/lua/lib/tweak_data/charactertweakdata.lua
+++ b/lua/lib/tweak_data/charactertweakdata.lua
@@ -8,63 +8,6 @@ function CharacterTweakData:init(tweak_data)
 	self:_init_deathvox(presets)
 end
 
-function CharacterTweakData:get_ai_group_type() -- I believe this function has been split and is uncalled. Will test removal in future branch.
-	local group_to_use = "zeal" 		
-						
-	if Global.level_data and Global.level_data.level_id then
-		level_id = Global.level_data.level_id
-	end
-	
-	if not Global.game_settings then
-		return group_to_use
-	end
-	local difficulties = {
-		"easy",
-		"normal",
-		"hard",
-		"overkill",
-		"overkill_145",
-		"easy_wish",
-		"overkill_290",
-		"sm_wish"
-	}
-	local map_faction_override = {} -- todo: global this
-	map_faction_override["Enemy_Spawner"] = "classic"
-	map_faction_override["pal"] = "classic"
-	map_faction_override["dah"] = "classic"
-	map_faction_override["red2"] = "classic"
-	map_faction_override["glace"] = "classic"
-	map_faction_override["run"] = "classic"
-	map_faction_override["flat"] = "classic"
-	map_faction_override["dinner"] = "classic"
-	map_faction_override["man"] = "classic"
-	map_faction_override["nmh"] = "classic"
-	-- whurr's map edits
-	map_faction_override["bridge"] = "classic"
-	map_faction_override["apartment"] = "classic"
-	map_faction_override["street"] = "classic"
-	map_faction_override["bank"] = "classic"
-	-- todo: setup akan on BP, murky on all murky heists, and classics on classic heists
-	local diff_index = table.index_of(difficulties, Global.game_settings.difficulty)
-	if diff_index <= 3 then
-		group_to_use = "cop"
-	elseif diff_index <= 5 then
-		group_to_use = "fbi"
-	elseif diff_index <= 7 then
-		group_to_use = "gensec"
-	end
-	if level_id then
-		if map_faction_override[level_id] then
-			group_to_use = map_faction_override[level_id]
-		end
-	end
-	if diff_index == 8 then -- kataru's reach is true
-		group_to_use = "zeal"
-	end
-	return group_to_use
-end
-
-
 function CharacterTweakData:_presets(tweak_data)
 	local presets = origin_presets(self, tweak_data)
 	presets.base.stealth_instant_kill = true


### PR DESCRIPTION
testing removal of apparently unused, duplicative faction code. Relevant material appears to now be handled in levelstweakdata.