### PR TITLE
Sniper fixes

### DIFF
--- a/lua/lib/tweak_data/charactertweakdata.lua
+++ b/lua/lib/tweak_data/charactertweakdata.lua
@@ -2285,6 +2285,84 @@ function CharacterTweakData:_presets(tweak_data)
 			}
 		}
 	}
+	presets.weapon.sniper.is_rifle = { -- directly replaces sniper weapon preset to match deathvox, for proper scaling purposes.
+		aim_delay = {
+			0,
+			0.1
+		},
+		focus_delay = 7,
+		focus_dis = 200,
+		spread = 30,
+		miss_dis = 250,
+		RELOAD_SPEED = 1.25,  -- validated, unchanged.
+		melee_speed = presets.weapon.normal.is_rifle.melee_speed,
+		melee_dmg = presets.weapon.normal.is_rifle.melee_dmg,
+		melee_retry_delay = presets.weapon.normal.is_rifle.melee_retry_delay,
+		range = { --validated, unchanged.
+			optimal = 15000,
+			far = 15000,
+			close = 15000
+		},
+		autofire_rounds = presets.weapon.normal.is_rifle.autofire_rounds,
+		use_laser = true,
+		FALLOFF = { -- note values do not match frank's table. Largely eyeballed, may need revision.
+			{
+				dmg_mul = 1,
+				r = 700,
+				acc = {
+					0.4,
+					0.95
+				},
+				recoil = {
+					2,
+					4
+				},
+				mode = {
+					1,
+					0,
+					0,
+					0
+				}
+			},
+			{
+				dmg_mul = .95, -- slight falloff, frank indicates flat damage on DW.
+				r = 4500,
+				acc = {
+					0.1,
+					0.75
+				},
+				recoil = {
+					3,
+					4
+				},
+				mode = {
+					1,
+					0,
+					0,
+					0
+				}
+			},
+			{
+				dmg_mul = .83,
+				r = 12000,
+				acc = {
+					0,
+					0.5
+				},
+				recoil = {
+					3,
+					5
+				},
+				mode = {
+					1,
+					0,
+					0,
+					0
+				}
+			}
+		}
+	}
+	
 	presets.weapon.deathvox_sniper.is_assault_sniper = deep_clone(presets.weapon.deathvox_sniper.is_rifle)
 	presets.weapon.deathvox.is_assault_sniper = deep_clone(presets.weapon.deathvox_sniper.is_rifle) --defining the assault sniper preset.
 	presets.weapon.deathvox.is_assault_sniper.FALLOFF = { -- revising assault sniper falloff values.
@@ -3544,6 +3622,17 @@ function CharacterTweakData:_set_easy_wish() -- MAYHEM specific tweaks begin.
 	self.deathvox_cloaker.dodge = deep_clone(self.presets.dodge.ninja) -- dodge to ninja (all below CD)
 	
 --	sniper - MAYHEM
+	self.deathvox_sniper_assault.weapon = deep_clone(self.presets.weapon.deathvox_sniper)
+	self.sniper = deep_clone(self.deathvox_sniper)
+	self.sniper.weapon = deep_clone(self.presets.weapon.deathvox_sniper)
+	--sniper weapon BS pls dont touch - Evilbobarino
+	--self.weap_unit_names[13] = Idstring("units/payday2/weapons/wpn_npc_sniper_cd/wpn_npc_sniper_cd")
+    --seriously please dont it will make me sad :<
+	--i am sorry little one - fuglore
+    self.deathvox_sniper.weapon.is_rifle.use_laser = false
+    self.sniper.weapon.is_rifle.use_laser = false
+    self.deathvox_sniper.disable_sniper_laser = true
+    self.sniper.weapon.disable_sniper_laser = true
 --	tank - MAYHEM
 	self.deathvox_tank.damage.explosion_damage_mul = 0.7 -- set 0.7 below CD.
 --	No specific unit curving for dozers, which all sync off of tank effects.	
@@ -3635,6 +3724,17 @@ function CharacterTweakData:_set_overkill_290() -- DEATH WISH specific tweaks be
 	self.deathvox_cloaker.dodge = deep_clone(self.presets.dodge.ninja) -- dodge to ninja (all below CD)
 	
 --	sniper - DEATH WISH
+	self.deathvox_sniper_assault.weapon = deep_clone(self.presets.weapon.deathvox_sniper)
+	self.sniper = deep_clone(self.deathvox_sniper)
+	self.sniper.weapon = deep_clone(self.presets.weapon.deathvox_sniper)
+	--sniper weapon BS pls dont touch - Evilbobarino
+	--self.weap_unit_names[13] = Idstring("units/payday2/weapons/wpn_npc_sniper_cd/wpn_npc_sniper_cd")
+    --seriously please dont it will make me sad :<
+	--i am sorry little one - fuglore
+    self.deathvox_sniper.weapon.is_rifle.use_laser = false
+    self.sniper.weapon.is_rifle.use_laser = false
+    self.deathvox_sniper.disable_sniper_laser = true
+    self.sniper.weapon.disable_sniper_laser = true
 --	tank - DEATH WISH
 	self.deathvox_tank.damage.explosion_damage_mul = 0.7 -- set 0.7 below CD.
 --	No specific unit curving for dozers, which all sync off of tank effects.	
@@ -3694,8 +3794,9 @@ function CharacterTweakData:_set_sm_wish() -- CRACKDOWN specific tweaks begin.
 	self.sniper = deep_clone(self.deathvox_sniper)
 	self.sniper.weapon = deep_clone(self.presets.weapon.deathvox_sniper)
 	--sniper weapon BS pls dont touch - Evilbobarino
-	self.weap_unit_names[13] = Idstring("units/payday2/weapons/wpn_npc_sniper_cd/wpn_npc_sniper_cd")
+	--self.weap_unit_names[13] = Idstring("units/payday2/weapons/wpn_npc_sniper_cd/wpn_npc_sniper_cd")
     --seriously please dont it will make me sad :<
+	--i am sorry little one - fuglore
     self.deathvox_sniper.weapon.is_rifle.use_laser = false
     self.sniper.weapon.is_rifle.use_laser = false
     self.deathvox_sniper.disable_sniper_laser = true

--- a/lua/lib/tweak_data/weapontweakdata.lua
+++ b/lua/lib/tweak_data/weapontweakdata.lua
@@ -503,11 +503,6 @@ end
 
 -- Begin NORMAL difficulty damage values. 
 
--- Fuglore here, I'd like to say that 1. You'll probably have to change some of the weapon usages if you haven't yet, and 2. You'll probably have to change some of the .unit files to have varied gun setups as to not cause horrible clashes in damage, and 3. You might have to add new weapon presets for Dozers, as their usages will be comparatively messy due to the Greendozer using the R870 and the LMGDozer using is_rifle behavior.
-
--- Begin difficulty scripted weapon damage value population.
-
--- Begin NORMAL difficulty damage values.
 
 function WeaponTweakData:_set_normal()
 
@@ -540,7 +535,7 @@ function WeaponTweakData:_set_normal()
 	self.asval_smg_npc.DAMAGE = 4.5 --Used by Akan Cloaker, mapped to Deathvox Cloaker SMG.
 	
 --	self.m14_npc.DAMAGE = 3		-- possibly unused.
---	self.m14_sniper_npc.DAMAGE = 3	-- possibly fully overwritten.
+	self.m14_sniper_npc.DAMAGE = 16	-- possibly fully overwritten.
 	
 	self.mp5_npc.DAMAGE = 2.5	-- smg used by number of units. Map to cop smg.
 	self.mp9_npc.DAMAGE = 2.5	-- shield only.	Map to cop smg.
@@ -670,7 +665,7 @@ function WeaponTweakData:_set_hard()
 	self.asval_smg_npc.DAMAGE = 6 --Used by Akan Cloaker, mapped to Deathvox Cloaker SMG.
 	
 --	self.m14_npc.DAMAGE = 3		-- possibly unused.
---	self.m14_sniper_npc.DAMAGE = 3	-- possibly fully overwritten.
+	self.m14_sniper_npc.DAMAGE = 16	-- possibly fully overwritten.
 	
 	self.mp5_npc.DAMAGE = 2.5	-- smg used by number of units. Map to cop smg.
 	self.mp9_npc.DAMAGE = 2.5	-- shield only.	Map to cop smg.
@@ -799,7 +794,7 @@ function WeaponTweakData:_set_overkill()
 	self.asval_smg_npc.DAMAGE = 6 --Used by Akan Cloaker, mapped to Deathvox Cloaker SMG.
 	
 --	self.m14_npc.DAMAGE = 3		-- possibly unused.
---	self.m14_sniper_npc.DAMAGE = 3	-- possibly fully overwritten.
+	self.m14_sniper_npc.DAMAGE = 18	-- possibly fully overwritten.
 	
 	self.mp5_npc.DAMAGE = 4.5	-- smg used by number of units. Map to cop smg.
 	self.mp9_npc.DAMAGE = 4.5	-- shield only.	Map to cop smg.
@@ -930,7 +925,7 @@ function WeaponTweakData:_set_overkill_145()
 	self.asval_smg_npc.DAMAGE = 6 --Used by Akan Cloaker, mapped to Deathvox Cloaker SMG.
 	
 --	self.m14_npc.DAMAGE = 3		-- possibly unused.
---	self.m14_sniper_npc.DAMAGE = 3	-- possibly fully overwritten.
+	self.m14_sniper_npc.DAMAGE = 20	-- possibly fully overwritten.
 	
 	self.mp5_npc.DAMAGE = 4.5	-- smg used by number of units. Map to cop smg.
 	self.mp9_npc.DAMAGE = 4.5	-- shield only.	Map to cop smg.
@@ -1060,7 +1055,11 @@ function WeaponTweakData:_set_easy_wish()
 	self.asval_smg_npc.DAMAGE = 6 --Used by Akan Cloaker, mapped to Deathvox Cloaker SMG.
 	
 --	self.m14_npc.DAMAGE = 3		-- possibly unused.
---	self.m14_sniper_npc.DAMAGE = 3	-- possibly fully overwritten.
+	self.m14_sniper_npc.DAMAGE = 20	-- sniper damage, set according to table.
+	self.m14_sniper_npc.sniper_trail = true
+	self.deathvox_sniper.sniper_trail = true
+	self.m14_sniper_npc.use_laser = false
+    self.m14_sniper_npc.disable_sniper_laser = true
 	
 	self.mp5_npc.DAMAGE = 6	-- smg used by number of units. Map to cop smg.
 	self.mp9_npc.DAMAGE = 6	-- shield only.	Map to cop smg.
@@ -1190,7 +1189,11 @@ function WeaponTweakData:_set_overkill_290()
 	self.asval_smg_npc.DAMAGE = 6 --Used by Akan Cloaker, mapped to Deathvox Cloaker SMG.
 	
 --	self.m14_npc.DAMAGE = 3		-- possibly unused.
---	self.m14_sniper_npc.DAMAGE = 3	-- possibly fully overwritten.
+	self.m14_sniper_npc.DAMAGE = 20	-- sniper damage, set according to table.
+	self.m14_sniper_npc.sniper_trail = true
+	self.deathvox_sniper.sniper_trail = true
+	self.m14_sniper_npc.use_laser = false
+    self.m14_sniper_npc.disable_sniper_laser = true
 	
 	self.mp5_npc.DAMAGE = 6	-- smg used by number of units. Map to cop smg.
 	self.mp9_npc.DAMAGE = 6	-- shield only.	Map to cop smg.
@@ -1320,10 +1323,12 @@ function WeaponTweakData:_set_sm_wish()
 	self.asval_smg_npc.DAMAGE = 7.5 --Used by Akan Cloaker, mapped to Deathvox Cloaker SMG.
 	
 --	self.m14_npc.DAMAGE = 3		-- possibly unused.
---	self.m14_sniper_npc.DAMAGE = 3	-- possibly fully overwritten.
+	self.m14_sniper_npc.DAMAGE = 24	-- sniper damage, set according to table
 	--Sniper Trail for Snipers
 	self.m14_sniper_npc.sniper_trail = true
 	self.deathvox_sniper.sniper_trail = true
+	self.m14_sniper_npc.use_laser = false
+    self.m14_sniper_npc.disable_sniper_laser = true
 	
 	
 	self.mp5_npc.DAMAGE = 7.5	-- smg used by number of units. Map to cop smg.


### PR DESCRIPTION
1. fixed lasers and glints usage to be set according to the agreed format:

- Lasers + Glint + Tracers on overkill and below

- Glint + Tracers only on Mayhem and above.

2. Fixed sniper damage across the board and made it actually scale according to the table:

160 on N/H.

180 on Very Hard.

200 on OVK/MH/DW.

240 on CD.