### PR TITLE
heist override stopped

### DIFF
--- a/map_replacements/Aftershock Crackdown/loc/english.txt
+++ b/map_replacements/Aftershock Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_jolly_name" : "Aftershock Crackdown",
-	"heist_jolly_brief" : "I've struck a deal with the biggest syndicate on the West coast, selling their safes on the East coast. Unfortunately, first shipment of safes ran unto a little trouble - a fucking earthquake! Can you believe that!? Get out there, ensure those safes are recovered. Fuck California.
+	"heist_jolly_cd_name" : "Aftershock Crackdown",
+	"heist_jolly_cd_brief" : "I've struck a deal with the biggest syndicate on the West coast, selling their safes on the East coast. Unfortunately, first shipment of safes ran unto a little trouble - a fucking earthquake! Can you believe that!? Get out there, ensure those safes are recovered. Fuck California.
 
 » Find Vlad's trucks
 » Open the trucks

--- a/map_replacements/Aftershock Crackdown/main.xml
+++ b/map_replacements/Aftershock Crackdown/main.xml
@@ -3,7 +3,7 @@
 		<texture load="true" path="guis/textures/crackdown"/>
 	</AddFiles>
 	<Localization default="english.txt" directory="loc"/>
-	<narrative briefing_event="vld_as1_cbf_01" contact="vlad" icon="guis/textures/crackdown" debrief_event="vld_as1_17" id="jolly" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_aftershock" region="street">
+	<narrative briefing_event="vld_as1_cbf_01" contact="vlad" icon="guis/textures/crackdown" debrief_event="vld_as1_17" id="jolly_cd" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_aftershock" region="street">
 		<chain>
 			<table level_id="jolly_CD" type="d" type_id="heist_type_assault"/>
 		</chain>

--- a/map_replacements/Alaskan Deal Crackdown/loc/english.txt
+++ b/map_replacements/Alaskan Deal Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_wwh_name" : "Alaskan Deal Crackdown",
-	"heist_wwh_brief" : "Dear friends, I need assistance unloading some weapons. I have set up a deal in Alaska, but I need an escort to keep the transaction secure, yeah?",
+	"heist_wwh_cd_name" : "Alaskan Deal Crackdown",
+	"heist_wwh_cd_brief" : "Dear friends, I need assistance unloading some weapons. I have set up a deal in Alaska, but I need an escort to keep the transaction secure, yeah?",
 	"heist_wwh_CD_name" : "Alaskan Deal Crackdown",
 	"heist_wwh_CD_brief" : "Locke has asked for help guarding a weapons transaction in Alaska. Says he's not expecting trouble, but wants some reliable security just in case. Looks like it might be an easy Payday if you can put up with the cold."
 }

--- a/map_replacements/Alaskan Deal Crackdown/main.xml
+++ b/map_replacements/Alaskan Deal Crackdown/main.xml
@@ -44,7 +44,7 @@
 			</mod>
 		</script_data_mods>
 	</level>
-	<narrative briefing_event="Play_loc_wwh_cbf_01" contact="locke" icon="guis/textures/crackdown" id="wwh" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_lockeload" region="street">
+	<narrative briefing_event="Play_loc_wwh_cbf_01" contact="locke" icon="guis/textures/crackdown" id="wwh_cd" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_lockeload" region="street">
 		<chain>
 			<table level_id="wwh_CD" type="d" type_id="heist_type_assault"/>
 		</chain>

--- a/map_replacements/Bank Cash Crackdown/loc/english.txt
+++ b/map_replacements/Bank Cash Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_branchbank_cash_name" : "Bank Heist: Cash Crackdown",
-	"heist_branchbank_cash_brief" : "Bain wants you to do a classic bank hit. This job is about the cash shipment the bank just received.
+	"heist_branchbank_cash_cd_name" : "Bank Heist: Cash Crackdown",
+	"heist_branchbank_cash_cd_brief" : "Bain wants you to do a classic bank hit. This job is about the cash shipment the bank just received.
 
 » Locate the bank
 » Find the thermal drill

--- a/map_replacements/Bank Cash Crackdown/main.xml
+++ b/map_replacements/Bank Cash Crackdown/main.xml
@@ -41,7 +41,7 @@
 		</packages>
 		<script_data_mods directory="scriptdata"/>
 	</level>
-	<narrative briefing_event="pln_branchbank_cash_brf_speak" contact="bain" icon="guis/textures/crackdown" id="branchbank_cash" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_branchbank" region="street">
+	<narrative briefing_event="pln_branchbank_cash_brf_speak" contact="bain" icon="guis/textures/crackdown" id="branchbank_cash_cd" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_branchbank" region="street">
 		<chain>
 			<table briefing_dialog="Play_pln_branchbank_cash_stage1_brief" briefing_id="heist_branchbank_cash_briefing" level_id="branchbank_cash_CD" mission="standalone" type="d" type_id="heist_type_assault">
 				<mission_filter>

--- a/map_replacements/Brooklyn 10-10 Crackdown/loc/english.txt
+++ b/map_replacements/Brooklyn 10-10 Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_spa_name" : "Brooklyn 10-10 Crackdown",
-	"heist_spa_brief" : "You're going to New York tonight. The Continental called - one of their key staff has been ambushed and is being held by unknown assailants at an address in Brooklyn. We have the location from a call he made just as they took him. The target's name is Charon. We need to get there fast, take out whoever's got him, and send him back to the Continental safe and sound.
+	"heist_spa_cd_name" : "Brooklyn 10-10 Crackdown",
+	"heist_spa_cd_brief" : "You're going to New York tonight. The Continental called - one of their key staff has been ambushed and is being held by unknown assailants at an address in Brooklyn. We have the location from a call he made just as they took him. The target's name is Charon. We need to get there fast, take out whoever's got him, and send him back to the Continental safe and sound.
 
  » Locate Charon
  » Rescue Charon and protect him from the attackers

--- a/map_replacements/Brooklyn 10-10 Crackdown/main.xml
+++ b/map_replacements/Brooklyn 10-10 Crackdown/main.xml
@@ -42,7 +42,7 @@
 			</mod>
 		</script_data_mods>
 	</level>
-	<narrative briefing_dialog="Play_pln_bb1_brf_01" briefing_event="pln_spa_cbf_01" contact="the_continental" cube="cube_apply_heist_bank" dlc="spa" ghost_bonus="0.15" icon="guis/textures/crackdown" id="spa" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_brooklyn1010" max_bags="28" region="street">
+	<narrative briefing_dialog="Play_pln_bb1_brf_01" briefing_event="pln_spa_cbf_01" contact="the_continental" cube="cube_apply_heist_bank" dlc="spa" ghost_bonus="0.15" icon="guis/textures/crackdown" id="spa_cd" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_brooklyn1010" max_bags="28" region="street">
 		<chain>
 			<table dlc="spa" level_id="spa_CD" type="d" type_id="heist_type_assault"/>
 		</chain>

--- a/map_replacements/Diamond Store Crackdown/loc/english.txt
+++ b/map_replacements/Diamond Store Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_family_name" : "Diamond Store Crackdown",
-	"heist_family_brief" : "This is a high fashion jewelry store. Mostly diamonds in there. Bain wants a lot of bags. There is an alarm connected to the display cases. It will be a tough one.
+	"heist_family_cd_name" : "Diamond Store Crackdown",
+	"heist_family_cd_brief" : "This is a high fashion jewelry store. Mostly diamonds in there. Bain wants a lot of bags. There is an alarm connected to the display cases. It will be a tough one.
 
 » Case the place carefully.
 » Check for guards, alarms and cameras

--- a/map_replacements/Diamond Store Crackdown/main.xml
+++ b/map_replacements/Diamond Store Crackdown/main.xml
@@ -42,7 +42,7 @@
 		</packages>
 		<script_data_mods directory="scriptdata"/>
 	</level>
-	<narrative briefing_event="pln_fj1_cbf_01" contact="bain" icon="guis/textures/crackdown" id="family" jc="20" load_screen="guis/dlcs/pic/textures/loading/job_diamondstore" region="street">
+	<narrative briefing_event="pln_fj1_cbf_01" contact="bain" icon="guis/textures/crackdown" id="family_cd" jc="20" load_screen="guis/dlcs/pic/textures/loading/job_diamondstore" region="street">
 		<chain>
 			<table level_id="family_CD" type="d" type_id="heist_type_assault"/>
 		</chain>

--- a/map_replacements/Shadow Raid Crackdown/loc/english.txt
+++ b/map_replacements/Shadow Raid Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_kosugi_name" : "Shadow Raid Crackdown",
-	"heist_kosugi_brief" : "Murkywater has a bonded warehouse down at the old wharf. See what sort of crap they're shipping back.
+	"heist_kosugi_cd_name" : "Shadow Raid Crackdown",
+	"heist_kosugi_cd_brief" : "Murkywater has a bonded warehouse down at the old wharf. See what sort of crap they're shipping back.
 
 » Break into the warehouse undetected
 » Steal anything valuable you can find

--- a/map_replacements/Shadow Raid Crackdown/main.xml
+++ b/map_replacements/Shadow Raid Crackdown/main.xml
@@ -41,7 +41,7 @@
 		</packages>
 		<script_data_mods directory="scriptdata"/>
 	</level>
-	<narrative briefing_event="pln_ko1_cbf_01" contact="bain" icon="guis/textures/crackdown" id="kosugi" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_shadow_raid" region="street">
+	<narrative briefing_event="pln_ko1_cbf_01" contact="bain" icon="guis/textures/crackdown" id="kosugi_cd" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_shadow_raid" region="street">
 		<chain>
 			<table level_id="kosugi_CD" type="d" type_id="heist_type_assault"/>
 		</chain>

--- a/map_replacements/Transport Crossroads Crackdown/loc/english.txt
+++ b/map_replacements/Transport Crossroads Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_arm_cro_name" : "Transport: Crossroads Crackdown",
-	"heist_arm_cro_brief" : "Bain has intercepted a convoy of armored Gensec trucks. They're carrying high-value cargo and you need to get in fast and steal it.
+	"heist_arm_cro_cd_name" : "Transport: Crossroads Crackdown",
+	"heist_arm_cro_cd_brief" : "Bain has intercepted a convoy of armored Gensec trucks. They're carrying high-value cargo and you need to get in fast and steal it.
 
 » Break into the immobilized trucks
 » Crack open the strongboxes

--- a/map_replacements/Transport Crossroads Crackdown/main.xml
+++ b/map_replacements/Transport Crossroads Crackdown/main.xml
@@ -44,7 +44,7 @@
 		</packages>
 		<script_data_mods directory="scriptdata"/>
 	</level>
-	<narrative briefing_event="pln_at1_cbf_01" contact="bain" dlc="armored_transport" icon="guis/textures/crackdown" id="cd_arm_cro" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_crossroads" region="street" spawn_chance_multiplier="0.5">
+	<narrative briefing_event="pln_at1_cbf_01" contact="bain" dlc="armored_transport" icon="guis/textures/crackdown" id="arm_cro_cd" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_crossroads" region="street" spawn_chance_multiplier="0.5">
 		<chain>
 			<table dlc="armored_transport" level_id="cd_arm_cro" type="d" type_id="heist_type_assault">
 				<mission_filter>

--- a/map_replacements/Transport Underpass Crackdown/loc/english.txt
+++ b/map_replacements/Transport Underpass Crackdown/loc/english.txt
@@ -1,6 +1,6 @@
 {
-	"heist_arm_und_name" : "Transport: Underpass Crackdown",
-	"heist_arm_und_brief" : "Bain has intercepted a convoy of armored Gensec trucks. They're carrying high-value cargo and you need to get in fast and steal it.
+	"heist_arm_und_cd_name" : "Transport: Underpass Crackdown",
+	"heist_arm_und_cd_brief" : "Bain has intercepted a convoy of armored Gensec trucks. They're carrying high-value cargo and you need to get in fast and steal it.
 
 » Break into the immobilized trucks
 » Crack open the strongboxes

--- a/map_replacements/Transport Underpass Crackdown/main.xml
+++ b/map_replacements/Transport Underpass Crackdown/main.xml
@@ -49,7 +49,7 @@
 			</mod>
 		</script_data_mods>
 	</level>
-	<narrative briefing_event="pln_at1_cbf_01" contact="bain" icon="guis/textures/crackdown" dlc="armored_transport" id="arm_und" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_underpass" region="street" spawn_chance_multiplier="0.5">
+	<narrative briefing_event="pln_at1_cbf_01" contact="bain" icon="guis/textures/crackdown" dlc="armored_transport" id="arm_und_cd" jc="30" load_screen="guis/dlcs/pic/textures/loading/job_underpass" region="street" spawn_chance_multiplier="0.5">
 		<chain>
 			<table dlc="armored_transport" level_id="arm_und_CD" type="d" type_id="heist_type_assault">
 				<mission_filter>


### PR DESCRIPTION
changes to id (under briefing in main xml) and loc file briefing references for all CD edit heists. Should cause heists to be displayed separately on crimenet.