### PR TITLE
Weapon stat utility + CRACKDOWN Perk Decks

### DIFF
--- a/lua/lib/managers/playermanager.lua
+++ b/lua/lib/managers/playermanager.lua
@@ -203,9 +203,10 @@ end
 function PlayerManager:movement_speed_multiplier(speed_state, bonus_multiplier, upgrade_level, health_ratio)
 	local multiplier = 1
 	local armor_penalty = self:mod_movement_penalty(self:body_armor_value("movement", upgrade_level, 1))
+	local fuckshit = (1 - armor_penalty) * 0.5
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		if self:upgrade_value("player", "armorer_t4") == true then
-			armor_penalty = armor_penalty * 1.5 -- this actually increases the speed, the var name is not very good
+			armor_penalty = 1 - fuckshit
 		end
 	end
 	multiplier = multiplier + armor_penalty - 1

--- a/lua/lib/managers/playermanager.lua
+++ b/lua/lib/managers/playermanager.lua
@@ -76,7 +76,7 @@ function PlayerManager:stamina_multiplier()
 	multiplier = managers.modifiers:modify_value("PlayerManager:GetStaminaMultiplier", multiplier)
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		if self:has_team_category_upgrade("player", "crew_chief_t3") == true then
-			multiplier = multiplier + 2 -- 100% more stamina
+			multiplier = multiplier + 1 -- 100% more stamina
 		end
 	end
 	return multiplier
@@ -96,20 +96,20 @@ function PlayerManager:health_skill_multiplier()
 	
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		if self:upgrade_value("player", "muscle_t9") == true then
-			multiplier = multiplier + 2.25
-		elseif self:upgrade_value("player", "muscle_t7") == true then
-			multiplier = multiplier + 2
-		elseif self:upgrade_value("player", "muscle_t5") == true then
-			multiplier = multiplier + 1.75
-		elseif self:upgrade_value("player", "muscle_t3") == true then
-			multiplier = multiplier + 1.5
-		elseif self:upgrade_value("player", "muscle_t1") == true then
 			multiplier = multiplier + 1.25
+		elseif self:upgrade_value("player", "muscle_t7") == true then
+			multiplier = multiplier + 1
+		elseif self:upgrade_value("player", "muscle_t5") == true then
+			multiplier = multiplier + 0.75
+		elseif self:upgrade_value("player", "muscle_t3") == true then
+			multiplier = multiplier + 0.5
+		elseif self:upgrade_value("player", "muscle_t1") == true then
+			multiplier = multiplier + 0.25
 		end
 		if self:has_team_category_upgrade("player", "crew_chief_t6") == true then
-			multiplier = multiplier + 1.3
+			multiplier = multiplier + 0.3
 		elseif self:has_team_category_upgrade("player", "crew_chief_t2") == true then
-			multiplier = multiplier + 1.15
+			multiplier = multiplier + 0.15
 		end
 	end
 	return multiplier
@@ -127,20 +127,20 @@ function PlayerManager:body_armor_skill_multiplier(override_armor)
 	multiplier = multiplier + self:upgrade_value("player", "chico_armor_multiplier", 1) - 1
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		if self:upgrade_value("player", "armorer_t9") == true then
-			multiplier = multiplier + 2
+			multiplier = multiplier + 1
 		elseif self:upgrade_value("player", "armorer_t7") == true then
-			multiplier = multiplier + 1.8
+			multiplier = multiplier + 0.8
 		elseif self:upgrade_value("player", "armorer_t5") == true then
-			multiplier = multiplier + 1.6
+			multiplier = multiplier + 0.6
 		elseif self:upgrade_value("player", "armorer_t3") == true then
-			multiplier = multiplier + 1.4
+			multiplier = multiplier + 0.4
 		elseif self:upgrade_value("player", "armorer_t1") == true then
-			multiplier = multiplier + 1.2
+			multiplier = multiplier + 0.2
 		end
 		if self:has_team_category_upgrade("player", "crew_chief_t8") == true then
-			multiplier = multiplier + 1.2
+			multiplier = multiplier + 0.2
 		elseif self:has_team_category_upgrade("player", "crew_chief_t4") == true then
-			multiplier = multiplier + 1.1
+			multiplier = multiplier + 0.1
 		end
 	end
 	return multiplier
@@ -165,15 +165,15 @@ function PlayerManager:body_armor_regen_multiplier(moving, health_ratio)
 	end
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		if self:upgrade_value("player", "armorer_t9") == true then
-			multiplier = multiplier + 1.25
+			multiplier = multiplier - 0.25
 		elseif self:upgrade_value("player", "armorer_t7") == true then
-			multiplier = multiplier + 1.2
+			multiplier = multiplier - 0.2
 		elseif self:upgrade_value("player", "armorer_t5") == true then
-			multiplier = multiplier + 1.15
+			multiplier = multiplier - 0.15
 		elseif self:upgrade_value("player", "armorer_t3") == true then
-			multiplier = multiplier + 1.1
+			multiplier = multiplier - 0.1
 		elseif self:upgrade_value("player", "armorer_t1") == true then
-			multiplier = multiplier + 1.05
+			multiplier = multiplier - 0.05
 		end
 		if self:has_team_category_upgrade("player", "crew_chief_t7") == true then
 			multiplier = multiplier - 0.1
@@ -296,7 +296,11 @@ function PlayerManager:skill_dodge_chance(running, crouching, on_zipline, overri
 		end
 		if self:upgrade_value("player", "rogue_t9") == true then
 			if detection_risk <= 35 then
-				local bonus_chance = 0.02 * (detection_risk / 2)
+				local detection_to_use = detection_risk
+				if detection_to_use < 3 then
+					detection_to_use = 3
+				end
+				local bonus_chance = 0.02 * (detection_to_use / 2)
 				if bonus_chance > 0.2 then
 					bonus_chance = 0.2
 				end

--- a/lua/lib/managers/playermanager.lua
+++ b/lua/lib/managers/playermanager.lua
@@ -58,9 +58,9 @@ function PlayerManager:damage_reduction_skill_multiplier(damage_type)
 		multiplier = multiplier * managers.player:upgrade_value("player", "interacting_damage_multiplier", 1)
 	end
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
-		if self:team_upgrade_value("player", "crew_chief_t9", false) then
+		if self:has_team_category_upgrade("player", "crew_chief_t9") then
 			multiplier = multiplier * 0.8 -- 20% damage reduction at t9
-		elseif self:team_upgrade_value("player", "crew_chief_t1", false) then
+		elseif self:has_team_category_upgrade("player", "crew_chief_t1") then
 			multiplier = multiplier * 0.9 -- but 10% at t1
 		end
 	end
@@ -75,7 +75,7 @@ function PlayerManager:stamina_multiplier()
 	multiplier = multiplier + self:get_hostage_bonus_multiplier("stamina") - 1
 	multiplier = managers.modifiers:modify_value("PlayerManager:GetStaminaMultiplier", multiplier)
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
-		if self:team_upgrade_value("player", "crew_chief_t3", false) then
+		if self:has_team_category_upgrade("player", "crew_chief_t3") == true then
 			multiplier = multiplier * 2 -- 100% more stamina
 		end
 	end
@@ -95,10 +95,21 @@ function PlayerManager:health_skill_multiplier()
 	end
 	
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
-		if self:team_upgrade_value("player", "crew_chief_t6", false) then
+		if self:has_team_category_upgrade("player", "crew_chief_t6") == true then
 			multiplier = multiplier * 1.3
-		elseif self:team_upgrade_value("player", "crew_chief_t2", false) then
+		elseif self:has_team_category_upgrade("player", "crew_chief_t2") == true then
 			multiplier = multiplier * 1.15
+		end
+		if self:upgrade_value("player", "muscle_t9") == true then
+			multiplier = multiplier * 2.25
+		elseif self:upgrade_value("player", "muscle_t7") == true then
+			multiplier = multiplier * 2
+		elseif self:upgrade_value("player", "muscle_t5") == true then
+			multiplier = multiplier * 1.75
+		elseif self:upgrade_value("player", "muscle_t3") == true then
+			multiplier = multiplier * 1.5
+		elseif self:upgrade_value("player", "muscle_t1") == true then
+			multiplier = multiplier * 1.25
 		end
 	end
 	return multiplier
@@ -115,9 +126,9 @@ function PlayerManager:body_armor_skill_multiplier(override_armor)
 	multiplier = multiplier + self:upgrade_value("player", tostring(override_armor or managers.blackmarket:equipped_armor(true, true)) .. "_armor_multiplier", 1) - 1
 	multiplier = multiplier + self:upgrade_value("player", "chico_armor_multiplier", 1) - 1
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
-		if self:team_upgrade_value("player", "crew_chief_t8", false) then
+		if self:has_team_category_upgrade("player", "crew_chief_t8") == true then
 			multiplier = multiplier * 1.2
-		elseif self:team_upgrade_value("player", "crew_chief_t4", false) then
+		elseif self:has_team_category_upgrade("player", "crew_chief_t4") == true then
 			multiplier = multiplier * 1.1
 		end
 	end
@@ -142,7 +153,7 @@ function PlayerManager:body_armor_regen_multiplier(moving, health_ratio)
 		multiplier = multiplier * (1 - managers.player:upgrade_value("player", "armor_regen_damage_health_ratio_multiplier", 0) * damage_health_ratio)
 	end
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
-		if self:team_upgrade_value("player", "crew_chief_t7", false) then
+		if self:has_team_category_upgrade("player", "crew_chief_t7") == true then
 			multiplier = multiplier * 0.9
 		end
 	end

--- a/lua/lib/managers/playermanager.lua
+++ b/lua/lib/managers/playermanager.lua
@@ -283,7 +283,6 @@ function PlayerManager:skill_dodge_chance(running, crouching, on_zipline, overri
 	chance = chance + self:upgrade_value("player", tostring(override_armor or managers.blackmarket:equipped_armor(true, true)) .. "_dodge_addend", 0)
 	chance = chance + self:upgrade_value("team", "crew_add_dodge", 0)
 	chance = chance + self:temporary_upgrade_value("temporary", "pocket_ecm_kill_dodge", 0)
-	log("detection risk: " .. detection_risk)
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		if self:upgrade_value("player", "rogue_t7") == true then
 			chance = chance + 0.4
@@ -295,12 +294,13 @@ function PlayerManager:skill_dodge_chance(running, crouching, on_zipline, overri
 			chance = chance + 0.1
 		end
 		if self:upgrade_value("player", "rogue_t9") == true then
-			if detection_risk <= 35 then
+			if not detection_risk == nil and detection_risk <= 35 then
 				local detection_to_use = detection_risk
 				if detection_to_use < 3 then
 					detection_to_use = 3
 				end
-				local bonus_chance = 0.02 * (detection_to_use / 2)
+				local points_for_math = 35 - detection_to_use
+				local bonus_chance = 0.02 * (points_for_math / 2)
 				if bonus_chance > 0.2 then
 					bonus_chance = 0.2
 				end
@@ -308,6 +308,7 @@ function PlayerManager:skill_dodge_chance(running, crouching, on_zipline, overri
 			end
 		end
 	end
+	log("dodge chance " .. chance)
 		
 
 	return chance

--- a/lua/lib/managers/playermanager.lua
+++ b/lua/lib/managers/playermanager.lua
@@ -21,3 +21,130 @@ function PlayerManager:_chk_fellow_crimin_proximity(unit)
 		
 	return players_nearby
 end
+
+function PlayerManager:damage_reduction_skill_multiplier(damage_type)
+	local multiplier = 1
+	multiplier = multiplier * self:temporary_upgrade_value("temporary", "dmg_dampener_outnumbered", 1)
+	multiplier = multiplier * self:temporary_upgrade_value("temporary", "dmg_dampener_outnumbered_strong", 1)
+	multiplier = multiplier * self:temporary_upgrade_value("temporary", "dmg_dampener_close_contact", 1)
+	multiplier = multiplier * self:temporary_upgrade_value("temporary", "revived_damage_resist", 1)
+	multiplier = multiplier * self:upgrade_value("player", "damage_dampener", 1)
+	multiplier = multiplier * self:upgrade_value("player", "health_damage_reduction", 1)
+	multiplier = multiplier * self:temporary_upgrade_value("temporary", "first_aid_damage_reduction", 1)
+	multiplier = multiplier * self:temporary_upgrade_value("temporary", "revive_damage_reduction", 1)
+	multiplier = multiplier * self:get_hostage_bonus_multiplier("damage_dampener")
+	multiplier = multiplier * self._properties:get_property("revive_damage_reduction", 1)
+	multiplier = multiplier * self._temporary_properties:get_property("revived_damage_reduction", 1)
+	local dmg_red_mul = self:team_upgrade_value("damage_dampener", "team_damage_reduction", 1)
+
+	if self:has_category_upgrade("player", "passive_damage_reduction") then
+		local health_ratio = self:player_unit():character_damage():health_ratio()
+		local min_ratio = self:upgrade_value("player", "passive_damage_reduction")
+
+		if health_ratio < min_ratio then
+			dmg_red_mul = dmg_red_mul - (1 - dmg_red_mul)
+		end
+	end
+
+	multiplier = multiplier * dmg_red_mul
+
+	if damage_type == "melee" then
+		multiplier = multiplier * managers.player:upgrade_value("player", "melee_damage_dampener", 1)
+	end
+
+	local current_state = self:get_current_state()
+
+	if current_state and current_state:_interacting() then
+		multiplier = multiplier * managers.player:upgrade_value("player", "interacting_damage_multiplier", 1)
+	end
+	if deathvox and deathvox:IsTotalCrackdownEnabled() then
+		if self:team_upgrade_value("player", "crew_chief_t9", false) then
+			multiplier = multiplier * 0.8 -- 20% damage reduction at t9
+		elseif self:team_upgrade_value("player", "crew_chief_t1", false) then
+			multiplier = multiplier * 0.9 -- but 10% at t1
+		end
+	end
+	return multiplier
+end
+
+function PlayerManager:stamina_multiplier()
+	local multiplier = 1
+	multiplier = multiplier + self:upgrade_value("player", "stamina_multiplier", 1) - 1
+	multiplier = multiplier + self:team_upgrade_value("stamina", "multiplier", 1) - 1
+	multiplier = multiplier + self:team_upgrade_value("stamina", "passive_multiplier", 1) - 1
+	multiplier = multiplier + self:get_hostage_bonus_multiplier("stamina") - 1
+	multiplier = managers.modifiers:modify_value("PlayerManager:GetStaminaMultiplier", multiplier)
+	if deathvox and deathvox:IsTotalCrackdownEnabled() then
+		if self:team_upgrade_value("player", "crew_chief_t3", false) then
+			multiplier = multiplier * 2 -- 100% more stamina
+		end
+	end
+	return multiplier
+end
+
+function PlayerManager:health_skill_multiplier()
+	local multiplier = 1
+	multiplier = multiplier + self:upgrade_value("player", "health_multiplier", 1) - 1
+	multiplier = multiplier + self:upgrade_value("player", "passive_health_multiplier", 1) - 1
+	multiplier = multiplier + self:team_upgrade_value("health", "passive_multiplier", 1) - 1
+	multiplier = multiplier + self:get_hostage_bonus_multiplier("health") - 1
+	multiplier = multiplier - self:upgrade_value("player", "health_decrease", 0)
+
+	if self:num_local_minions() > 0 then
+		multiplier = multiplier + self:upgrade_value("player", "minion_master_health_multiplier", 1) - 1
+	end
+	
+	if deathvox and deathvox:IsTotalCrackdownEnabled() then
+		if self:team_upgrade_value("player", "crew_chief_t6", false) then
+			multiplier = multiplier * 1.3
+		elseif self:team_upgrade_value("player", "crew_chief_t2", false) then
+			multiplier = multiplier * 1.15
+		end
+	end
+	return multiplier
+end
+
+function PlayerManager:body_armor_skill_multiplier(override_armor)
+	local multiplier = 1
+	multiplier = multiplier + self:upgrade_value("player", "tier_armor_multiplier", 1) - 1
+	multiplier = multiplier + self:upgrade_value("player", "passive_armor_multiplier", 1) - 1
+	multiplier = multiplier + self:upgrade_value("player", "armor_multiplier", 1) - 1
+	multiplier = multiplier + self:team_upgrade_value("armor", "multiplier", 1) - 1
+	multiplier = multiplier + self:get_hostage_bonus_multiplier("armor") - 1
+	multiplier = multiplier + self:upgrade_value("player", "perk_armor_loss_multiplier", 1) - 1
+	multiplier = multiplier + self:upgrade_value("player", tostring(override_armor or managers.blackmarket:equipped_armor(true, true)) .. "_armor_multiplier", 1) - 1
+	multiplier = multiplier + self:upgrade_value("player", "chico_armor_multiplier", 1) - 1
+	if deathvox and deathvox:IsTotalCrackdownEnabled() then
+		if self:team_upgrade_value("player", "crew_chief_t8", false) then
+			multiplier = multiplier * 1.2
+		elseif self:team_upgrade_value("player", "crew_chief_t4", false) then
+			multiplier = multiplier * 1.1
+		end
+	end
+	return multiplier
+end
+
+function PlayerManager:body_armor_regen_multiplier(moving, health_ratio)
+	local multiplier = 1
+	multiplier = multiplier * self:upgrade_value("player", "armor_regen_timer_multiplier_tier", 1)
+	multiplier = multiplier * self:upgrade_value("player", "armor_regen_timer_multiplier", 1)
+	multiplier = multiplier * self:upgrade_value("player", "armor_regen_timer_multiplier_passive", 1)
+	multiplier = multiplier * self:team_upgrade_value("armor", "regen_time_multiplier", 1)
+	multiplier = multiplier * self:team_upgrade_value("armor", "passive_regen_time_multiplier", 1)
+	multiplier = multiplier * self:upgrade_value("player", "perk_armor_regen_timer_multiplier", 1)
+
+	if not moving then
+		multiplier = multiplier * managers.player:upgrade_value("player", "armor_regen_timer_stand_still_multiplier", 1)
+	end
+
+	if health_ratio then
+		local damage_health_ratio = self:get_damage_health_ratio(health_ratio, "armor_regen")
+		multiplier = multiplier * (1 - managers.player:upgrade_value("player", "armor_regen_damage_health_ratio_multiplier", 0) * damage_health_ratio)
+	end
+	if deathvox and deathvox:IsTotalCrackdownEnabled() then
+		if self:team_upgrade_value("player", "crew_chief_t7", false) then
+			multiplier = multiplier * 0.9
+		end
+	end
+	return multiplier
+end

--- a/lua/lib/tweak_data/skilltreetweakdata.lua
+++ b/lua/lib/tweak_data/skilltreetweakdata.lua
@@ -348,6 +348,120 @@ Hooks:PostHook(SkillTreeTweakData, "init", "vox_overhaul_init", function(self)
 			desc_id = "muscle_deck_desc",
 			name_id = "muscle_deck"
 		}
+		-- Muscle
+		self.specializations[3] = {
+			{
+				cost = 200,
+				desc_id = "armorer_t1_desc",
+				name_id = "armorer_t1_name",
+				upgrades = {
+					"armorer_t1",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 300,
+				desc_id = "armorer_t2_desc",
+				name_id = "armorer_t2_name",
+				upgrades = {
+					"armorer_t2",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 400,
+				desc_id = "armorer_t3_desc",
+				name_id = "armorer_t3_name",
+				upgrades = {
+					"armorer_t3"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 600,
+				desc_id = "armorer_t4_desc",
+				name_id = "armorer_t4_name",
+				upgrades = {
+					"armorer_t4"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 1000,
+				desc_id = "armorer_t5_desc",
+				name_id = "armorer_t5_name",
+				upgrades = {
+					"armorer_t5"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 1600,
+				desc_id = "armorer_t6_desc",
+				name_id = "armorer_t6_name",
+				upgrades = {
+					"armorer_t6"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 2400,
+				desc_id = "armorer_t7_desc",
+				name_id = "armorer_t7_name",
+				upgrades = {
+					"armorer_t7"
+				},
+				icon_xy = {
+					6,
+					0
+				}
+			},
+			{
+				cost = 3200,
+				desc_id = "armorer_t8_desc",
+				name_id = "armorer_t8_name",
+				upgrades = {
+					"armorer_t8"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 4000,
+				desc_id = "armorer_t9_desc",
+				name_id = "armorer_t9_name",
+				upgrades = {
+					"armorer_t9"
+				},
+				icon_xy = {
+					0,
+					1
+				}
+			},
+			desc_id = "armorer_deck_desc",
+			name_id = "armorer_deck"
+		}
+		
 		
 	end
 end)

--- a/lua/lib/tweak_data/skilltreetweakdata.lua
+++ b/lua/lib/tweak_data/skilltreetweakdata.lua
@@ -574,8 +574,232 @@ Hooks:PostHook(SkillTreeTweakData, "init", "vox_overhaul_init", function(self)
 			desc_id = "rogue_deck_desc",
 			name_id = "rogue_deck"
 		}
-		
-		
+		-- Crook
+		self.specializations[6] = {
+			{
+				cost = 200,
+				desc_id = "crook_t1_desc",
+				name_id = "crook_t1_name",
+				upgrades = {
+					"crook_t1",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 300,
+				desc_id = "crook_t2_desc",
+				name_id = "crook_t2_name",
+				upgrades = {
+					"crook_t2",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 400,
+				desc_id = "crook_t3_desc",
+				name_id = "crook_t3_name",
+				upgrades = {
+					"crook_t3"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 600,
+				desc_id = "crook_t4_desc",
+				name_id = "crook_t4_name",
+				upgrades = {
+					"crook_t4"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 1000,
+				desc_id = "crook_t5_desc",
+				name_id = "crook_t5_name",
+				upgrades = {
+					"crook_t5"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 1600,
+				desc_id = "crook_t6_desc",
+				name_id = "crook_t6_name",
+				upgrades = {
+					"crook_t6"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 2400,
+				desc_id = "crook_t7_desc",
+				name_id = "crook_t7_name",
+				upgrades = {
+					"crook_t7"
+				},
+				icon_xy = {
+					6,
+					0
+				}
+			},
+			{
+				cost = 3200,
+				desc_id = "crook_t8_desc",
+				name_id = "crook_t8_name",
+				upgrades = {
+					"crook_t8"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 4000,
+				desc_id = "crook_t9_desc",
+				name_id = "crook_t9_name",
+				upgrades = {
+					"temporary_berserker_damage_multiplier_1"
+				},
+				icon_xy = {
+					0,
+					1
+				}
+			},
+			desc_id = "crook_deck_desc",
+			name_id = "crook_deck"
+		}
+		-- Hitman
+		self.specializations[5] = {
+			{
+				cost = 200,
+				desc_id = "hitman_t1_desc",
+				name_id = "hitman_t1_name",
+				upgrades = {
+					"hitman_t1",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 300,
+				desc_id = "hitman_t2_desc",
+				name_id = "hitman_t2_name",
+				upgrades = {
+					"hitman_t2",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 400,
+				desc_id = "hitman_t3_desc",
+				name_id = "hitman_t3_name",
+				upgrades = {
+					"hitman_t3"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 600,
+				desc_id = "hitman_t4_desc",
+				name_id = "hitman_t4_name",
+				upgrades = {
+					"hitman_t4"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 1000,
+				desc_id = "hitman_t5_desc",
+				name_id = "hitman_t5_name",
+				upgrades = {
+					"hitman_t5"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 1600,
+				desc_id = "hitman_t6_desc",
+				name_id = "hitman_t6_name",
+				upgrades = {
+					"hitman_t6"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 2400,
+				desc_id = "hitman_t7_desc",
+				name_id = "hitman_t7_name",
+				upgrades = {
+					"hitman_t7"
+				},
+				icon_xy = {
+					6,
+					0
+				}
+			},
+			{
+				cost = 3200,
+				desc_id = "hitman_t8_desc",
+				name_id = "hitman_t8_name",
+				upgrades = {
+					"hitman_t8"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 4000,
+				desc_id = "hitman_t9_desc",
+				name_id = "hitman_t9_name",
+				upgrades = {
+					"hitman_t9"
+				},
+				icon_xy = {
+					0,
+					1
+				}
+			},
+			desc_id = "hitman_deck_desc",
+			name_id = "hitman_deck"
+		}
 	end
 end)
 

--- a/lua/lib/tweak_data/skilltreetweakdata.lua
+++ b/lua/lib/tweak_data/skilltreetweakdata.lua
@@ -235,6 +235,119 @@ Hooks:PostHook(SkillTreeTweakData, "init", "vox_overhaul_init", function(self)
 			desc_id = "crew_chief_deck_desc",
 			name_id = "crew_chief_deck"
 		}
+		-- Muscle
+		self.specializations[2] = {
+			{
+				cost = 200,
+				desc_id = "muscle_t1_desc",
+				name_id = "muscle_t1_name",
+				upgrades = {
+					"muscle_t1",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 300,
+				desc_id = "muscle_t2_desc",
+				name_id = "muscle_t2_name",
+				upgrades = {
+					"muscle_t2",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 400,
+				desc_id = "muscle_t3_desc",
+				name_id = "muscle_t3_name",
+				upgrades = {
+					"muscle_t3"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 600,
+				desc_id = "muscle_t4_desc",
+				name_id = "muscle_t4_name",
+				upgrades = {
+					"muscle_t4"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 1000,
+				desc_id = "muscle_t5_desc",
+				name_id = "muscle_t5_name",
+				upgrades = {
+					"muscle_t5"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 1600,
+				desc_id = "muscle_t6_desc",
+				name_id = "muscle_t6_name",
+				upgrades = {
+					"muscle_t6"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 2400,
+				desc_id = "muscle_t7_desc",
+				name_id = "muscle_t7_name",
+				upgrades = {
+					"muscle_t7"
+				},
+				icon_xy = {
+					6,
+					0
+				}
+			},
+			{
+				cost = 3200,
+				desc_id = "muscle_t8_desc",
+				name_id = "muscle_t8_name",
+				upgrades = {
+					"muscle_t8"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 4000,
+				desc_id = "muscle_t9_desc",
+				name_id = "muscle_t9_name",
+				upgrades = {
+					"muscle_t9"
+				},
+				icon_xy = {
+					0,
+					1
+				}
+			},
+			desc_id = "muscle_deck_desc",
+			name_id = "muscle_deck"
+		}
 		
 	end
 end)

--- a/lua/lib/tweak_data/skilltreetweakdata.lua
+++ b/lua/lib/tweak_data/skilltreetweakdata.lua
@@ -348,7 +348,7 @@ Hooks:PostHook(SkillTreeTweakData, "init", "vox_overhaul_init", function(self)
 			desc_id = "muscle_deck_desc",
 			name_id = "muscle_deck"
 		}
-		-- Muscle
+		-- Armorer
 		self.specializations[3] = {
 			{
 				cost = 200,
@@ -460,6 +460,119 @@ Hooks:PostHook(SkillTreeTweakData, "init", "vox_overhaul_init", function(self)
 			},
 			desc_id = "armorer_deck_desc",
 			name_id = "armorer_deck"
+		}
+		-- Rogue
+		self.specializations[4] = {
+			{
+				cost = 200,
+				desc_id = "rogue_t1_desc",
+				name_id = "rogue_t1_name",
+				upgrades = {
+					"rogue_t1",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 300,
+				desc_id = "rogue_t2_desc",
+				name_id = "rogue_t2_name",
+				upgrades = {
+					"rogue_t2",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 400,
+				desc_id = "rogue_t3_desc",
+				name_id = "rogue_t3_name",
+				upgrades = {
+					"rogue_t3"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 600,
+				desc_id = "rogue_t4_desc",
+				name_id = "rogue_t4_name",
+				upgrades = {
+					"rogue_t4"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 1000,
+				desc_id = "rogue_t5_desc",
+				name_id = "rogue_t5_name",
+				upgrades = {
+					"rogue_t5"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 1600,
+				desc_id = "rogue_t6_desc",
+				name_id = "rogue_t6_name",
+				upgrades = {
+					"rogue_t6"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 2400,
+				desc_id = "rogue_t7_desc",
+				name_id = "rogue_t7_name",
+				upgrades = {
+					"rogue_t7"
+				},
+				icon_xy = {
+					6,
+					0
+				}
+			},
+			{
+				cost = 3200,
+				desc_id = "rogue_t8_desc",
+				name_id = "rogue_t8_name",
+				upgrades = {
+					"rogue_t8"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 4000,
+				desc_id = "rogue_t9_desc",
+				name_id = "rogue_t9_name",
+				upgrades = {
+					"rogue_t9"
+				},
+				icon_xy = {
+					0,
+					1
+				}
+			},
+			desc_id = "rogue_deck_desc",
+			name_id = "rogue_deck"
 		}
 		
 		

--- a/lua/lib/tweak_data/skilltreetweakdata.lua
+++ b/lua/lib/tweak_data/skilltreetweakdata.lua
@@ -121,6 +121,121 @@ Hooks:PostHook(SkillTreeTweakData, "init", "vox_overhaul_init", function(self)
 		
 		--Demolitions
 		
+		-- Perk Decks
+		-- DON'T TAMPER WITH THE COSTS! This can cause save file problems.
+		self.specializations[1] = {
+			{
+				cost = 200,
+				desc_id = "crew_chief_t1_desc",
+				name_id = "crew_chief_t1_name",
+				upgrades = {
+					"crew_chief_t1",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 300,
+				desc_id = "crew_chief_t2_desc",
+				name_id = "crew_chief_t2_name",
+				upgrades = {
+					"crew_chief_t2",
+				},
+				icon_xy = {
+					0,
+					0
+				}
+			},
+			{
+				cost = 400,
+				desc_id = "crew_chief_t3_desc",
+				name_id = "crew_chief_t3_name",
+				upgrades = {
+					"crew_chief_t3"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 600,
+				desc_id = "crew_chief_t4_desc",
+				name_id = "crew_chief_t4_name",
+				upgrades = {
+					"crew_chief_t4"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 1000,
+				desc_id = "crew_chief_t5_desc",
+				name_id = "crew_chief_t5_name",
+				upgrades = {
+					"crew_chief_t5"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 1600,
+				desc_id = "crew_chief_t6_desc",
+				name_id = "crew_chief_t6_name",
+				upgrades = {
+					"crew_chief_t6"
+				},
+				icon_xy = {
+					2,
+					0
+				}
+			},
+			{
+				cost = 2400,
+				desc_id = "crew_chief_t7_desc",
+				name_id = "crew_chief_t7_name",
+				upgrades = {
+					"crew_chief_t7"
+				},
+				icon_xy = {
+					6,
+					0
+				}
+			},
+			{
+				cost = 3200,
+				desc_id = "crew_chief_t8_desc",
+				name_id = "crew_chief_t8_name",
+				upgrades = {
+					"crew_chief_t8"
+				},
+				icon_xy = {
+					4,
+					0
+				}
+			},
+			{
+				cost = 4000,
+				desc_id = "crew_chief_t9_desc",
+				name_id = "crew_chief_t9_name",
+				upgrades = {
+					"crew_chief_t9"
+				},
+				icon_xy = {
+					0,
+					1
+				}
+			},
+			desc_id = "crew_chief_deck_desc",
+			name_id = "crew_chief_deck"
+		}
+		
 	end
 end)
 

--- a/lua/lib/tweak_data/upgradestweakdata.lua
+++ b/lua/lib/tweak_data/upgradestweakdata.lua
@@ -515,5 +515,133 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 				category = "player"
 			}
 		}
+		-- rogue
+		self.values.player.rogue_t1 = {
+			true
+		}
+		
+		self.definitions.rogue_t1 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t1",
+				category = "player"
+			}
+		}
+		
+		self.values.player.rogue_t2 = {
+			true
+		}
+		
+		self.definitions.rogue_t2 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t2",
+				category = "player"
+			}
+		}
+
+		self.values.player.rogue_t3 = {
+			true
+		}
+		
+		self.definitions.rogue_t3 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t3",
+				category = "player"
+			}
+		}
+		
+		self.values.player.rogue_t4 = {
+			true
+		}
+		
+		self.definitions.rogue_t4 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t4",
+				category = "player"
+			}
+		}
+		
+		self.values.player.rogue_t5 = {
+			true
+		}
+		
+		self.definitions.rogue_t5 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t5",
+				category = "player"
+			}
+		}
+
+		self.values.player.rogue_t6 = {
+			true
+		}
+		
+		self.definitions.rogue_t6 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t6",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.rogue_t7 = {
+			true
+		}
+		
+		self.definitions.rogue_t7 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t7",
+				category = "player"
+			}
+		}
+
+		self.values.player.rogue_t8 = {
+			true
+		}
+		
+		self.definitions.rogue_t8 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t8",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.rogue_t9 = {
+			true
+		}	
+		
+		self.definitions.rogue_t9 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "rogue_t9",
+				category = "player"
+			}
+		}
 	end	
 end)

--- a/lua/lib/tweak_data/upgradestweakdata.lua
+++ b/lua/lib/tweak_data/upgradestweakdata.lua
@@ -131,5 +131,134 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 		
 		--Demolitions
 		
+		-- Perk Decks
+		
+		-- Crew Chief
+		self.values.player.crew_chief_t1 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t1 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t1",
+				category = "crew_chief"
+			}
+		}
+		
+		self.values.player.crew_chief_t2 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t2 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t2",
+				category = "crew_chief"
+			}
+		}
+
+		self.values.player.crew_chief_t3 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t3 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t3",
+				category = "crew_chief"
+			}
+		}
+		
+		self.values.player.crew_chief_t4 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t4 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t4",
+				category = "crew_chief"
+			}
+		}
+		
+		self.values.player.crew_chief_t5 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t5 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t5",
+				category = "crew_chief"
+			}
+		}
+
+		self.values.player.crew_chief_t6 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t6 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t6",
+				category = "crew_chief"
+			}
+		}
+
+		self.values.player.crew_chief_t7 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t7 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t7",
+				category = "crew_chief"
+			}
+		}
+
+		self.values.player.crew_chief_t8 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t8 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t8",
+				category = "crew_chief"
+			}
+		}
+
+
+		self.values.player.crew_chief_t9 = {
+			true
+		}
+		
+		self.definitions.crew_chief_t9 = {
+			name_id = "unused",
+			category = "team",
+			upgrade = {
+				value = 1,
+				upgrade = "crew_chief_t9",
+				category = "crew_chief"
+			}
+		}
 	end	
 end)

--- a/lua/lib/tweak_data/upgradestweakdata.lua
+++ b/lua/lib/tweak_data/upgradestweakdata.lua
@@ -387,5 +387,133 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 				category = "player"
 			}
 		}
+		-- Armorer
+		self.values.player.armorer_t1 = {
+			true
+		}
+		
+		self.definitions.armorer_t1 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t1",
+				category = "player"
+			}
+		}
+		
+		self.values.player.armorer_t2 = {
+			true
+		}
+		
+		self.definitions.armorer_t2 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t2",
+				category = "player"
+			}
+		}
+
+		self.values.player.armorer_t3 = {
+			true
+		}
+		
+		self.definitions.armorer_t3 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t3",
+				category = "player"
+			}
+		}
+		
+		self.values.player.armorer_t4 = {
+			true
+		}
+		
+		self.definitions.armorer_t4 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t4",
+				category = "player"
+			}
+		}
+		
+		self.values.player.armorer_t5 = {
+			true
+		}
+		
+		self.definitions.armorer_t5 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t5",
+				category = "player"
+			}
+		}
+
+		self.values.player.armorer_t6 = {
+			true
+		}
+		
+		self.definitions.armorer_t6 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t6",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.armorer_t7 = {
+			true
+		}
+		
+		self.definitions.armorer_t7 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t7",
+				category = "player"
+			}
+		}
+
+		self.values.player.armorer_t8 = {
+			true
+		}
+		
+		self.definitions.armorer_t8 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t8",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.armorer_t9 = {
+			true
+		}
+		
+		self.definitions.armorer_t9 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "armorer_t9",
+				category = "player"
+			}
+		}
 	end	
 end)

--- a/lua/lib/tweak_data/upgradestweakdata.lua
+++ b/lua/lib/tweak_data/upgradestweakdata.lua
@@ -144,7 +144,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t1",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 		
@@ -158,7 +158,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t2",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 
@@ -172,7 +172,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t3",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 		
@@ -186,7 +186,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t4",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 		
@@ -200,7 +200,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t5",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 
@@ -214,7 +214,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t6",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 
@@ -228,7 +228,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t7",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 
@@ -242,7 +242,7 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t8",
-				category = "crew_chief"
+				category = "player"
 			}
 		}
 
@@ -257,7 +257,134 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			upgrade = {
 				value = 1,
 				upgrade = "crew_chief_t9",
-				category = "crew_chief"
+				category = "player"
+			}
+		}
+		-- Muscle
+		self.values.player.muscle_t1 = {
+			true
+		}
+		
+		self.definitions.muscle_t1 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t1",
+				category = "player"
+			}
+		}
+		
+		self.values.player.muscle_t2 = {
+			true
+		}
+		
+		self.definitions.muscle_t2 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t2",
+				category = "player"
+			}
+		}
+
+		self.values.player.muscle_t3 = {
+			true
+		}
+		
+		self.definitions.muscle_t3 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t3",
+				category = "player"
+			}
+		}
+		
+		self.values.player.muscle_t4 = {
+			true
+		}
+		
+		self.definitions.muscle_t4 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t4",
+				category = "player"
+			}
+		}
+		
+		self.values.player.muscle_t5 = {
+			true
+		}
+		
+		self.definitions.muscle_t5 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t5",
+				category = "player"
+			}
+		}
+
+		self.values.player.muscle_t6 = {
+			true
+		}
+		
+		self.definitions.muscle_t6 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t6",
+				category = "player"
+			}
+		}
+
+		self.values.player.muscle_t7 = {
+			true
+		}
+		
+		self.definitions.muscle_t7 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t7",
+				category = "player"
+			}
+		}
+
+		self.values.player.muscle_t8 = {
+			true
+		}
+		
+		self.definitions.muscle_t8 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t8",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.muscle_t9 = {
+			true
+		}
+		
+		self.definitions.muscle_t9 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "muscle_t9",
+				category = "player"
 			}
 		}
 	end	

--- a/lua/lib/tweak_data/upgradestweakdata.lua
+++ b/lua/lib/tweak_data/upgradestweakdata.lua
@@ -629,17 +629,408 @@ Hooks:PostHook(UpgradesTweakData, "init", "vox_overhaul1", function(self, tweak_
 			}
 		}
 
-
-		self.values.player.rogue_t9 = {
-			true
-		}	
-		
 		self.definitions.rogue_t9 = {
 			name_id = "unused",
 			category = "feature",
 			upgrade = {
 				value = 1,
 				upgrade = "rogue_t9",
+				category = "player"
+			}
+		}
+		
+		self.values.player.rogue_t9 = { -- The values for the Sneaky Bastard knockoff skill
+			{
+				0.02,
+				2,
+				"below",
+				35,
+				0.2
+			}
+		}
+		-- Crook
+		self.values.player.crook_t1 = {
+			true
+		}
+		
+		self.definitions.crook_t1 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t1",
+				category = "player"
+			}
+		}
+		
+		self.values.player.crook_t2 = {
+			true
+		}
+		
+		self.definitions.crook_t2 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t2",
+				category = "player"
+			}
+		}
+
+		self.values.player.crook_t3 = {
+			true
+		}
+		
+		self.definitions.crook_t3 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t3",
+				category = "player"
+			}
+		}
+		
+		self.values.player.crook_t4 = {
+			true
+		}
+		
+		self.definitions.crook_t4 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t4",
+				category = "player"
+			}
+		}
+		
+		self.values.player.crook_t5 = {
+			true
+		}
+		
+		self.definitions.crook_t5 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t5",
+				category = "player"
+			}
+		}
+
+		self.values.player.crook_t6 = {
+			true
+		}
+		
+		self.definitions.crook_t6 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t6",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.crook_t7 = {
+			true
+		}
+		
+		self.definitions.crook_t7 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t7",
+				category = "player"
+			}
+		}
+
+		self.values.player.crook_t8 = {
+			true
+		}
+		
+		self.definitions.crook_t8 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "crook_t8",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.crook_t9 = {
+			true
+		}
+
+		self.values.temporary.berserker_damage_multiplier = {
+			{
+				1,
+				4
+			},
+			{
+				1,
+				4
+			}
+		}
+		-- Hitman
+		self.values.player.passive_always_regen_armor = {
+			2,
+			1.75,
+			1.5,
+			1.25
+		}
+		self.values.player.hitman_t1 = {
+			true
+		}
+		
+		self.definitions.hitman_t1 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "hitman_t1",
+				category = "player"
+			}
+		}
+		
+		self.values.player.hitman_t2 = {
+			true
+		}
+		
+		self.definitions.hitman_t2 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "passive_always_regen_armor",
+				category = "player"
+			}
+		}
+
+		self.values.player.hitman_t3 = {
+			true
+		}
+		
+		self.definitions.hitman_t3 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "hitman_t3",
+				category = "player"
+			}
+		}
+		
+		self.values.player.hitman_t4 = {
+			true
+		}
+		
+		self.definitions.hitman_t4 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 2,
+				upgrade = "passive_always_regen_armor",
+				category = "player"
+			}
+		}
+		
+		self.values.player.hitman_t5 = {
+			true
+		}
+		
+		self.definitions.hitman_t5 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "hitman_t5",
+				category = "player"
+			}
+		}
+
+		self.values.player.hitman_t6 = {
+			true
+		}
+		
+		self.definitions.hitman_t6 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 3,
+				upgrade = "passive_always_regen_armor",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.hitman_t7 = {
+			true
+		}
+		
+		self.definitions.hitman_t7 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "hitman_t7",
+				category = "player"
+			}
+		}
+
+		self.values.player.hitman_t8 = {
+			true
+		}
+		
+		self.definitions.hitman_t8 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 4,
+				upgrade = "passive_always_regen_armor",
+				category = "player"
+			}
+		}
+
+		self.definitions.hitman_t9 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "messiah_revive_from_bleed_out",
+				category = "player"
+			}
+		}
+		-- Burglar
+		self.values.player.burglar_t1 = {
+			true
+		}
+		
+		self.definitions.burglar_t1 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t1",
+				category = "player"
+			}
+		}
+		
+		self.values.player.burglar_t2 = {
+			true
+		}
+		
+		self.definitions.burglar_t2 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t2",
+				category = "player"
+			}
+		}
+
+		self.values.player.burglar_t3 = {
+			true
+		}
+		
+		self.definitions.burglar_t3 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t3",
+				category = "player"
+			}
+		}
+		
+		self.values.player.burglar_t4 = {
+			true
+		}
+		
+		self.definitions.burglar_t4 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t4",
+				category = "player"
+			}
+		}
+		
+		self.values.player.burglar_t5 = {
+			true
+		}
+		
+		self.definitions.burglar_t5 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t5",
+				category = "player"
+			}
+		}
+
+		self.values.player.burglar_t6 = {
+			true
+		}
+		
+		self.definitions.burglar_t6 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t6",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.burglar_t7 = {
+			true
+		}
+		
+		self.definitions.burglar_t7 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t7",
+				category = "player"
+			}
+		}
+
+		self.values.player.burglar_t8 = {
+			true
+		}
+		
+		self.definitions.burglar_t8 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t8",
+				category = "player"
+			}
+		}
+
+
+		self.values.player.burglar_t9 = {
+			true
+		}
+		
+		self.definitions.burglar_t9 = {
+			name_id = "unused",
+			category = "feature",
+			upgrade = {
+				value = 1,
+				upgrade = "burglar_t9",
 				category = "player"
 			}
 		}

--- a/lua/lib/tweak_data/weapontweakdata.lua
+++ b/lua/lib/tweak_data/weapontweakdata.lua
@@ -8497,6 +8497,78 @@ Hooks:PostHook(WeaponTweakData, "_init_data_player_weapons", "vox_wep", function
 		}
 		
 		--Miniguns end here.
+		-- Automated processing of values.
+		-- i am not manually doin the goddamn math to figure out the proper fire rate for each damn gun lmao
+		-- fire rate: 1 /(rate / 60)
+		-- stability: recoil * (1/3)
+		-- spread: accuracy * (1/3)
+		-- suppression: (43 - threat) / 3
+		if deathvox and deathvox:IsTotalCrackdownEnabled() then
+			for k,v in pairs(self) do
+				log("processing weapon " .. k)
+				if self[k] and self[k]["cd_stability"] then
+					self[k]["stats"]["recoil"] = math.ceil((self[k]["cd_stability"] * (1/3)))
+					log("stability set to " .. self[k]["stats"]["recoil"])
+				end
+				if self[k] and self[k]["cd_spread"] then
+					self[k]["stats"]["spread"] = math.ceil((self[k]["cd_spread"] * (1/3)))
+					self[k]["stats"]["spread_moving"] = math.ceil((self[k]["cd_spread"] * (1/3)))
+					self[k]["spread"] = {
+						standing = math.ceil((self[k]["cd_spread"] * (1/3)))
+					}
+					self[k]["spread"]["crouching"] = self[k]["spread"]["standing"] * 0.4
+					self[k]["spread"]["steelsight"] = self[k]["spread"]["standing"] * 0.4
+					self[k]["spread"]["moving_standing"] = self[k]["spread"]["standing"]
+					self[k]["spread"]["moving_crouching"] = self[k]["spread"]["standing"]
+					self[k]["spread"]["moving_steelsight"] = self[k]["spread"]["steelsight"]
+					log("spread set to " .. self[k]["stats"]["spread"])
+				end
+				if self[k] and self[k]["cd_rpm"] then
+					self[k]["fire_mode_data"]["fire_rate"] = 1 / (self[k]["cd_rpm"] / 60)
+					self[k]["auto"]["fire_rate"] = 1 / (self[k]["cd_rpm"] / 60)
+					log("fire rate set to " .. self[k]["auto"]["fire_rate"])
+				end
+				if self[k] and self[k]["cd_threat"] then
+					self[k]["stats"]["suppression"] = math.ceil((43 - self[k]["cd_threat"]) / 3)
+					log("threat set to " .. self[k]["stats"]["suppression"])
+				end
+				if self[k] and self[k]["cd_ammosetup"] then
+					self[k]["CLIP_AMMO_MAX"] = self[k]["cd_ammosetup"]["clip_size"]
+					self[k]["NR_CLIPS_MAX"] = self[k]["cd_ammosetup"]["total_ammo"] / self[k]["cd_ammosetup"]["clip_size"]
+					self[k]["AMMO_MAX"] = self[k]["CLIP_AMMO_MAX"] * self[k]["NR_CLIPS_MAX"]
+					log("maximum ammo set to " .. self[k]["AMMO_MAX"])
+				end
+			end
+		end
+		--[[
+		WEAPON TEMPLATE:
+		self.weaponid.cd_stability =
+		self.weaponid.cd_spread =
+		self.weaponid.cd_rpm =
+		self.weaponid.cd_threat =
+		self.weaponid.cd_ammosetup =
+		{
+			clip_size =,
+			total_ammo =
+		}
+		self.weaponid.stats.damage =
+		self.weaponid.stats.concealment =
+		self.weaponid.timers = 
+		{
+			reload_not_empty = ,
+			reload_empty = ,
+			unequip = ,
+			equip = 
+		}
+		self.weaponid.AMMO_PICKUP = {
+			1,
+			1
+		}
+		self.weaponid.categories = {
+			"assault_rifle",
+			"rapidfire"
+		}
+		]]--
 
 	end
 end)

--- a/lua/lib/units/beings/player/playerdamage.lua
+++ b/lua/lib/units/beings/player/playerdamage.lua
@@ -767,8 +767,17 @@ function PlayerDamage:_upd_health_regen(t, dt)
 			local max_health = self:_max_health()
 			local missing_health = max_health - self:get_real_health()
 			if self:get_real_health() < max_health then
-				if pm:team_upgrade_value("player", "crew_chief_t5", false) then
+				if pm:has_team_category_upgrade("player", "crew_chief_t5") == true then
 					self:restore_health(missing_health * 0.01, true)
+				end
+				if pm:upgrade_value("player", "muscle_t8") == true then
+					self:restore_health(max_health * 0.02, true)
+				elseif pm:upgrade_value("player", "muscle_t6") == true then
+					self:restore_health(max_health * 0.015, true)
+				elseif pm:upgrade_value("player", "muscle_t4") == true then
+					self:restore_health(max_health * 0.01, true)
+				elseif pm:upgrade_value("player", "muscle_t2") == true then
+					self:restore_health(max_health * 0.005, true)
 				end
 				self._crew_chief_regen_timer = 1
 			end

--- a/lua/lib/units/beings/player/playerdamage.lua
+++ b/lua/lib/units/beings/player/playerdamage.lua
@@ -875,7 +875,6 @@ function PlayerDamage:damage_tase(attack_data)
 		local attacker = attack_data.attacker_unit
 		if self._rogue_dodge_tase_cooldown <= managers.player:player_timer():time() then
 			if managers.player:upgrade_value("player", "rogue_t6") == true then
-				self:play_whizby(attack_data.col_ray.position)
 				self._rogue_dodge_tase_cooldown = managers.player:player_timer():time() + 10
 				return
 			end

--- a/lua/lib/units/beings/player/playerdamage.lua
+++ b/lua/lib/units/beings/player/playerdamage.lua
@@ -908,3 +908,103 @@ function PlayerDamage:damage_tase(attack_data)
 		end
 	end
 end
+
+function PlayerDamage:damage_fall(data)
+	local damage_info = {
+		result = {
+			variant = "fall",
+			type = "hurt"
+		}
+	}
+
+	if self._god_mode or self._invulnerable or self._mission_damage_blockers.invulnerable then
+		self:_call_listeners(damage_info)
+
+		return
+	elseif self:incapacitated() then
+		return
+	elseif self._unit:movement():current_state().immortal then
+		return
+	elseif self._mission_damage_blockers.damage_fall_disabled then
+		return
+	end
+
+	local height_limit = 300
+	local death_limit = 631
+	
+	if managers.player:upgrade_value("player", "burglar_t4") == true then
+		death_limit = death_limit * 2
+	end
+
+	if data.height < height_limit then
+		return
+	end
+
+	local die = death_limit < data.height
+
+	self._unit:sound():play("player_hit")
+	managers.environment_controller:hit_feedback_down()
+	managers.hud:on_hit_direction(Vector3(0, 0, 0), die and HUDHitDirection.DAMAGE_TYPES.HEALTH or HUDHitDirection.DAMAGE_TYPES.ARMOUR, 0)
+
+	if self._bleed_out and self._unit:movement():current_state_name() ~= "jerry1" then
+		return
+	end
+
+	local health_damage_multiplier = 0
+
+	if die then
+		self._check_berserker_done = false
+
+		self:set_health(0)
+
+		if self._unit:movement():current_state_name() == "jerry1" then
+			self._revives = Application:digest_value(1, true)
+		end
+	else
+
+		health_damage_multiplier = managers.player:upgrade_value("player", "fall_damage_multiplier", 1) * managers.player:upgrade_value("player", "fall_health_damage_multiplier", 1)
+		if managers.player:upgrade_value("player", "burglar_t4") == true then
+			health_damage_multiplier = 0 -- no fall damage unless it would kill you
+		end
+		self:change_health(-(tweak_data.player.fall_health_damage * health_damage_multiplier))
+	end
+
+	if die or health_damage_multiplier > 0 then
+		local alert_rad = tweak_data.player.fall_damage_alert_size or 500
+		local new_alert = {
+			"vo_cbt",
+			self._unit:movement():m_head_pos(),
+			alert_rad,
+			self._unit:movement():SO_access(),
+			self._unit
+		}
+
+		managers.groupai:state():propagate_alert(new_alert)
+	end
+
+	local max_armor = self:_max_armor()
+
+	if die then
+		self:set_armor(0)
+	else
+		self:change_armor(-max_armor * managers.player:upgrade_value("player", "fall_damage_multiplier", 1))
+	end
+
+	SoundDevice:set_rtpc("shield_status", 0)
+	self:_send_set_armor()
+
+	self._bleed_out_blocked_by_movement_state = nil
+
+	managers.hud:set_player_health({
+		current = self:get_real_health(),
+		total = self:_max_health(),
+		revives = Application:digest_value(self._revives, false)
+	})
+	self:_send_set_health()
+	self:_set_health_effect()
+	self:_damage_screen()
+	self:_check_bleed_out(nil, true)
+	self:_call_listeners(damage_info)
+
+	return true
+end

--- a/lua/lib/units/beings/player/playerdamage.lua
+++ b/lua/lib/units/beings/player/playerdamage.lua
@@ -44,20 +44,18 @@ function PlayerDamage:damage_bullet(attack_data)
 
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		local pm = managers.player
-		if self._rogue_dodge_sniper_bullet_cooldown then
-			self._rogue_dodge_sniper_bullet_cooldown = self._rogue_dodge_sniper_bullet_cooldown - dt
-
-			if self._rogue_dodge_sniper_bullet_cooldown <= 0 then
-				self._rogue_dodge_sniper_bullet_cooldown = nil
-			end
+		if not self._rogue_dodge_sniper_bullet_cooldown then
+			self._rogue_dodge_sniper_bullet_cooldown = managers.player:player_timer():time()
 		end
 		local attacker = attack_data.attacker_unit
-		local is_sniper = attacker:base():has_tag("sniper")
-		if not self._rogue_dodge_sniper_bullet_cooldown and is_sniper then
-			if managers.player:upgrade_value("player", "rogue_t4") == true then
-				self:play_whizby(attack_data.col_ray.position)
-				self._rogue_dodge_sniper_bullet_cooldown = 10
-				return
+		if attacker:base().has_tag then
+			local is_sniper = attacker:base():has_tag("sniper")
+			if is_sniper and self._rogue_dodge_sniper_bullet_cooldown <= managers.player:player_timer():time() then
+				if managers.player:upgrade_value("player", "rogue_t4") == true then
+					self:play_whizby(attack_data.col_ray.position)
+					self._rogue_dodge_sniper_bullet_cooldown = managers.player:player_timer():time() + 10
+					return
+				end
 			end
 		end
 	end
@@ -316,18 +314,14 @@ function PlayerDamage:damage_melee(attack_data)
 	
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		local pm = managers.player
-		if self._rogue_dodge_melee_cooldown then
-			self._rogue_dodge_melee_cooldown = self._rogue_dodge_melee_cooldown - dt
-
-			if self._rogue_dodge_melee_cooldown <= 0 then
-				self._rogue_dodge_melee_cooldown = nil
-			end
+		if not self._rogue_dodge_melee_cooldown then
+			self._rogue_dodge_melee_cooldown = managers.player:player_timer():time()
 		end
 		local attacker = attack_data.attacker_unit
-		if not self._rogue_dodge_melee_cooldown then
+		if self._rogue_dodge_melee_cooldown <= managers.player:player_timer():time() then
 			if managers.player:upgrade_value("player", "rogue_t2") == true then
 				self:play_whizby(attack_data.col_ray.position)
-				self._rogue_dodge_melee_cooldown = 10
+				self._rogue_dodge_melee_cooldown = managers.player:player_timer():time() + 10
 				return
 			end
 		end
@@ -875,17 +869,14 @@ function PlayerDamage:damage_tase(attack_data)
 
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		local pm = managers.player
-		if self._rogue_dodge_tase_cooldown then
-			self._rogue_dodge_tase_cooldown = self._rogue_dodge_tase_cooldown - dt
-
-			if self._rogue_dodge_tase_cooldown <= 0 then
-				self._rogue_dodge_tase_cooldown = nil
-			end
-		end
 		if not self._rogue_dodge_tase_cooldown then
-			if managers.player:upgrade_value("player", "rogue_t8") == true then
+			self._rogue_dodge_tase_cooldown = managers.player:player_timer():time()
+		end
+		local attacker = attack_data.attacker_unit
+		if self._rogue_dodge_tase_cooldown <= managers.player:player_timer():time() then
+			if managers.player:upgrade_value("player", "rogue_t6") == true then
 				self:play_whizby(attack_data.col_ray.position)
-				self._rogue_dodge_tase_cooldown = 10
+				self._rogue_dodge_tase_cooldown = managers.player:player_timer():time() + 10
 				return
 			end
 		end

--- a/lua/lib/units/beings/player/playermovement.lua
+++ b/lua/lib/units/beings/player/playermovement.lua
@@ -112,7 +112,6 @@ function PlayerMovement:on_SPOOCed(enemy_unit)
 		if not self._rogue_dodge_cloaker_cooldown then
 			self._rogue_dodge_cloaker_cooldown = managers.player:player_timer():time()
 		end
-		local attacker = attack_data.attacker_unit
 		if self._rogue_dodge_cloaker_cooldown <= managers.player:player_timer():time() then
 			if managers.player:upgrade_value("player", "rogue_t8") == true then
 				self._rogue_dodge_cloaker_cooldown = managers.player:player_timer():time() + 10

--- a/lua/lib/units/beings/player/playermovement.lua
+++ b/lua/lib/units/beings/player/playermovement.lua
@@ -95,3 +95,43 @@ function PlayerMovement:on_non_lethal_electrocution()
 		self._unit:sound():say("s07x_sin", true)
 	end
 end
+
+function PlayerMovement:on_SPOOCed(enemy_unit)
+	if managers.player:has_category_upgrade("player", "counter_strike_spooc") and self._current_state.in_melee and self._current_state:in_melee() then
+		self._current_state:discharge_melee()
+
+		return "countered"
+	end
+
+	if self._unit:character_damage()._god_mode or self._unit:character_damage():get_mission_blocker("invulnerable") then
+		return
+	end
+	
+	if deathvox and deathvox:IsTotalCrackdownEnabled() then
+		local pm = managers.player
+		if self._rogue_dodge_cloaker_cooldown then
+			self._rogue_dodge_cloaker_cooldown = self._rogue_dodge_cloaker_cooldown - dt
+
+			if self._rogue_dodge_cloaker_cooldown <= 0 then
+				self._rogue_dodge_cloaker_cooldown = nil
+			end
+		end
+		if not self._rogue_dodge_cloaker_cooldown then
+			if managers.player:upgrade_value("player", "rogue_t6") == true then
+				self._rogue_dodge_cloaker_cooldown = 10
+				return false
+			end
+		end
+	end
+
+	if self._current_state_name == "standard" or self._current_state_name == "carry" or self._current_state_name == "bleed_out" or self._current_state_name == "tased" or self._current_state_name == "bipod" then
+		local state = "incapacitated"
+		state = managers.modifiers:modify_value("PlayerMovement:OnSpooked", state)
+
+		managers.player:set_player_state(state)
+		managers.achievment:award(tweak_data.achievement.finally.award)
+
+		return true
+	end
+end
+

--- a/lua/lib/units/beings/player/playermovement.lua
+++ b/lua/lib/units/beings/player/playermovement.lua
@@ -109,17 +109,14 @@ function PlayerMovement:on_SPOOCed(enemy_unit)
 	
 	if deathvox and deathvox:IsTotalCrackdownEnabled() then
 		local pm = managers.player
-		if self._rogue_dodge_cloaker_cooldown then
-			self._rogue_dodge_cloaker_cooldown = self._rogue_dodge_cloaker_cooldown - dt
-
-			if self._rogue_dodge_cloaker_cooldown <= 0 then
-				self._rogue_dodge_cloaker_cooldown = nil
-			end
-		end
 		if not self._rogue_dodge_cloaker_cooldown then
-			if managers.player:upgrade_value("player", "rogue_t6") == true then
-				self._rogue_dodge_cloaker_cooldown = 10
-				return false
+			self._rogue_dodge_cloaker_cooldown = managers.player:player_timer():time()
+		end
+		local attacker = attack_data.attacker_unit
+		if self._rogue_dodge_cloaker_cooldown <= managers.player:player_timer():time() then
+			if managers.player:upgrade_value("player", "rogue_t8") == true then
+				self._rogue_dodge_cloaker_cooldown = managers.player:player_timer():time() + 10
+				return
 			end
 		end
 	end

--- a/lua/lib/units/interactions/interactionext.lua
+++ b/lua/lib/units/interactions/interactionext.lua
@@ -26,3 +26,52 @@ if deathvox:IsTotalCrackdownEnabled() then
 		end
 	end
 end
+
+function BaseInteractionExt:_get_timer()
+	local modified_timer = self:_get_modified_timer()
+
+	if modified_timer then
+		return modified_timer
+	end
+
+	local multiplier = 1
+
+	if self.tweak_data ~= "corpse_alarm_pager" then
+		multiplier = multiplier * managers.player:crew_ability_upgrade_value("crew_interact", 1)
+		if managers.groupai:state():whisper_mode() then
+			if managers.player:upgrade_value("player", "burglar_t9") == true then
+				multiplier = multiplier - 0.25
+			elseif managers.player:upgrade_value("player", "burglar_t7") == true then
+				multiplier = multiplier - 0.2
+			elseif managers.player:upgrade_value("player", "burglar_t5") == true then
+				multiplier = multiplier - 0.15
+			elseif managers.player:upgrade_value("player", "burglar_t3") == true then
+				multiplier = multiplier - 0.1
+			elseif managers.player:upgrade_value("player", "burglar_t1") == true then
+				multiplier = multiplier - 0.05
+			end
+		end
+	else
+		if managers.player:upgrade_value("player", "burglar_t8") == true then
+			multiplier = multiplier - 0.1
+		end
+	end
+
+	if self._tweak_data.upgrade_timer_multiplier then
+		multiplier = multiplier * managers.player:upgrade_value(self._tweak_data.upgrade_timer_multiplier.category, self._tweak_data.upgrade_timer_multiplier.upgrade, 1)
+	end
+
+	if self._tweak_data.upgrade_timer_multipliers then
+		for _, upgrade_timer_multiplier in pairs(self._tweak_data.upgrade_timer_multipliers) do
+			multiplier = multiplier * managers.player:upgrade_value(upgrade_timer_multiplier.category, upgrade_timer_multiplier.upgrade, 1)
+		end
+	end
+
+	if managers.player:has_category_upgrade("player", "level_interaction_timer_multiplier") then
+		local data = managers.player:upgrade_value("player", "level_interaction_timer_multiplier") or {}
+		local player_level = managers.experience:current_level() or 0
+		multiplier = multiplier * (1 - (data[1] or 0) * math.ceil(player_level / (data[2] or 1)))
+	end
+
+	return self:_timer_value() * multiplier * managers.player:toolset_value()
+end

--- a/lua/loc/loc.lua
+++ b/lua/loc/loc.lua
@@ -130,32 +130,32 @@ Hooks:Add("LocalizationManagerPostInit", "DeathVox_Overhaul", function(loc)
 				-- Rogue
 				["rogue_deck"] = "Rogue: CRACKDOWN",
 				["rogue_deck_desc"] = "Provides Dodge Chance and comes with Special Dodges that are guaranteed to avoid certain attacks. Features a rebranded Sneaky Bastard.",
-				["rogue_t1_name"] = "",
-				["rogue_t1_desc"] = "",
+				["rogue_t1_name"] = "Fat Chance",
+				["rogue_t1_desc"] = "You gain ##+10%## Dodge Chance.",
 
-				["rogue_t2_name"] = "",
-				["rogue_t2_desc"] = "",
+				["rogue_t2_name"] = "Hands Off",
+				["rogue_t2_desc"] = "You are ##guaranteed## to Dodge an enemy Melee attack. This effect has a ##10 second cooldown##.",
 
-				["rogue_t3_name"] = "",
-				["rogue_t3_desc"] = "",
+				["rogue_t3_name"] = "Playing the Odds",
+				["rogue_t3_desc"] = "Increases your Dodge Chance bonus to ##+20%##.",
 
-				["rogue_t4_name"] = "",
-				["rogue_t4_desc"] = "",
+				["rogue_t4_name"] = "Elusive Target",
+				["rogue_t4_desc"] = "You are ##guaranteed## to Dodge a Sniper’s shot. This effect has a ##10 second cooldown##.",
 
-				["rogue_t5_name"] = "",
-				["rogue_t5_desc"] = "",
+				["rogue_t5_name"] = "Tricky Business",
+				["rogue_t5_desc"] = "Increases your Dodge Chance bonus to ##+30%##.",
 
-				["rogue_t6_name"] = "",
-				["rogue_t6_desc"] = "",
+				["rogue_t6_name"] = "Kansas City Shuffle",
+				["rogue_t6_desc"] = "You are ##guaranteed## to Dodge a Cloaker’s kick. This effect has a ##10 second cooldown##.",
 
-				["rogue_t7_name"] = "",
-				["rogue_t7_desc"] = "",
+				["rogue_t7_name"] = "Isai’s Wisdom",
+				["rogue_t7_desc"] = "Increases your Dodge Chance bonus to ##+40%##.",
 
-				["rogue_t8_name"] = "",
-				["rogue_t8_desc"] = "",
+				["rogue_t8_name"] = "The Electric Slide",
+				["rogue_t8_desc"] = "You are ##guaranteed## to Dodge a Taser’s shock attack. This effect has a ##10 second cooldown##.",
 
-				["rogue_t9_name"] = "",
-				["rogue_t9_desc"] = ""
+				["rogue_t9_name"] = "Smooth Criminal",
+				["rogue_t9_desc"] = "You gain a bonus ##+2%## Dodge Chance for every ##2 points of Detection Risk## under ##35##, up to ##+20%##."
 
 			})
 		end

--- a/lua/loc/loc.lua
+++ b/lua/loc/loc.lua
@@ -72,32 +72,32 @@ Hooks:Add("LocalizationManagerPostInit", "DeathVox_Overhaul", function(loc)
 				-- Muscle
 				["muscle_deck"] = "Muscle: CRACKDOWN",
 				["muscle_deck_desc"] = "Massive Health and Health Regeneration. Flex eternal!",
-				["muscle_t1_name"] = "",
-				["muscle_t1_desc"] = "",
+				["muscle_t1_name"] = "Dynamic Tension",
+				["muscle_t1_desc"] = "You gain +25% Maximum Health and you become 25% more likely to be targeted over your teammates.",
 
-				["muscle_t2_name"] = "",
-				["muscle_t2_desc"] = "",
+				["muscle_t2_name"] = "Endurance Training",
+				["muscle_t2_desc"] = "You regenerate 0.5% of your Maximum Health per second.",
 
-				["muscle_t3_name"] = "",
-				["muscle_t3_desc"] = "",
+				["muscle_t3_name"] = "Chump into Champ",
+				["muscle_t3_desc"] = "Increases your Maximum Health bonus to +50%.",
 
-				["muscle_t4_name"] = "",
-				["muscle_t4_desc"] = "",
+				["muscle_t4_name"] = "Dauntless Improvement",
+				["muscle_t4_desc"] = "Your Health Regeneration increases to 1% of your Maximum Health per second.",
 
-				["muscle_t5_name"] = "",
-				["muscle_t5_desc"] = "",
+				["muscle_t5_name"] = "15 Minutes A Day",
+				["muscle_t5_desc"] = "Increases your Maximum Health bonus to +75%.",
 
-				["muscle_t6_name"] = "",
-				["muscle_t6_desc"] = "",
+				["muscle_t6_name"] = "Tireless Physique",
+				["muscle_t6_desc"] = "Your Health Regeneration increases to 1.5% of your Maximum Health per second.",
 
-				["muscle_t7_name"] = "",
-				["muscle_t7_desc"] = "",
+				["muscle_t7_name"] = "Muscle Mystery",
+				["muscle_t7_desc"] = "Increases your Maximum Health bonus to +100%.",
 
-				["muscle_t8_name"] = "",
-				["muscle_t8_desc"] = "",
+				["muscle_t8_name"] = "Flex Eternal",
+				["muscle_t8_desc"] = "Your Health Regeneration increases to 2% of your Maximum Health per second.",
 
-				["muscle_t9_name"] = "",
-				["muscle_t9_desc"] = "",
+				["muscle_t9_name"] = "Hero Of The Beach",
+				["muscle_t9_desc"] = "Increases your Maximum Health bonus to +125%.",
 				-- Armorer
 				["armorer_deck"] = "Armorer: CRACKDOWN",
 				["armorer_deck_desc"] = "Heavy Armor all day, every day.",

--- a/lua/loc/loc.lua
+++ b/lua/loc/loc.lua
@@ -73,60 +73,60 @@ Hooks:Add("LocalizationManagerPostInit", "DeathVox_Overhaul", function(loc)
 				["muscle_deck"] = "Muscle: CRACKDOWN",
 				["muscle_deck_desc"] = "Massive Health and Health Regeneration. Flex eternal!",
 				["muscle_t1_name"] = "Dynamic Tension",
-				["muscle_t1_desc"] = "You gain +25% Maximum Health and you become 25% more likely to be targeted over your teammates.",
+				["muscle_t1_desc"] = "You gain ##+25%## Maximum Health and you become ##25%## more likely to be targeted over your teammates.",
 
 				["muscle_t2_name"] = "Endurance Training",
-				["muscle_t2_desc"] = "You regenerate 0.5% of your Maximum Health per second.",
+				["muscle_t2_desc"] = "You regenerate ##0.5%## of your Maximum Health per second.",
 
 				["muscle_t3_name"] = "Chump into Champ",
-				["muscle_t3_desc"] = "Increases your Maximum Health bonus to +50%.",
+				["muscle_t3_desc"] = "Increases your Maximum Health bonus to ##+50%##.",
 
 				["muscle_t4_name"] = "Dauntless Improvement",
-				["muscle_t4_desc"] = "Your Health Regeneration increases to 1% of your Maximum Health per second.",
+				["muscle_t4_desc"] = "Your Health Regeneration increases to ##1%## of your Maximum Health per second.",
 
 				["muscle_t5_name"] = "15 Minutes A Day",
-				["muscle_t5_desc"] = "Increases your Maximum Health bonus to +75%.",
+				["muscle_t5_desc"] = "Increases your Maximum Health bonus to ##+75%##.",
 
 				["muscle_t6_name"] = "Tireless Physique",
-				["muscle_t6_desc"] = "Your Health Regeneration increases to 1.5% of your Maximum Health per second.",
+				["muscle_t6_desc"] = "Your Health Regeneration increases to ##1.5%## of your Maximum Health per second.",
 
 				["muscle_t7_name"] = "Muscle Mystery",
-				["muscle_t7_desc"] = "Increases your Maximum Health bonus to +100%.",
+				["muscle_t7_desc"] = "Increases your Maximum Health bonus to ##+100%##.",
 
 				["muscle_t8_name"] = "Flex Eternal",
-				["muscle_t8_desc"] = "Your Health Regeneration increases to 2% of your Maximum Health per second.",
+				["muscle_t8_desc"] = "Your Health Regeneration increases to ##2%## of your Maximum Health per second.",
 
 				["muscle_t9_name"] = "Hero Of The Beach",
-				["muscle_t9_desc"] = "Increases your Maximum Health bonus to +125%.",
+				["muscle_t9_desc"] = "Increases your Maximum Health bonus to ##+125%##.",
 				-- Armorer
 				["armorer_deck"] = "Armorer: CRACKDOWN",
 				["armorer_deck_desc"] = "Heavy Armor all day, every day.",
-				["armorer_t1_name"] = "",
-				["armorer_t1_desc"] = "",
+				["armorer_t1_name"] = "MK1 Plating",
+				["armorer_t1_desc"] = "You gain ##+20%## Maximum Armor and ##+5%## Armor Recovery Rate.",
 
-				["armorer_t2_name"] = "",
-				["armorer_t2_desc"] = "",
+				["armorer_t2_name"] = "Steadfast",
+				["armorer_t2_desc"] = "##Doubles## the Steadiness of your equipped Armor, reducing how much you Flinch from taking Damage.",
 
-				["armorer_t3_name"] = "",
-				["armorer_t3_desc"] = "",
+				["armorer_t3_name"] = "MK2 Plating",
+				["armorer_t3_desc"] = "Increases your Maximum Armor bonus to ##+40%## and Armor Recovery Rate bonus to ##+10%##.",
 
-				["armorer_t4_name"] = "",
-				["armorer_t4_desc"] = "",
+				["armorer_t4_name"] = "Armored Grace",
+				["armorer_t4_desc"] = "Your Speed penalty for wearing Armor is reduced by ##50%##.",
 
-				["armorer_t5_name"] = "",
-				["armorer_t5_desc"] = "",
+				["armorer_t5_name"] = "MK3 Plating",
+				["armorer_t5_desc"] = "Increases your Maximum Armor bonus to ##+60%## and Armor Recovery Rate bonus to ##+15%##.",
 
-				["armorer_t6_name"] = "",
-				["armorer_t6_desc"] = "",
+				["armorer_t6_name"] = "Reactive Armor",
+				["armorer_t6_desc"] = "You are rendered ##Invulnerable## to damage for ##2 seconds## after your Armor breaks. This effect has a ##10 second cooldown##.",
 
-				["armorer_t7_name"] = "",
-				["armorer_t7_desc"] = "",
+				["armorer_t7_name"] = "MK4 Plating",
+				["armorer_t7_desc"] = "Increases your Maximum Armor bonus to ##+80%## and Armor Recovery Rate bonus to ##+20%##.",
 
-				["armorer_t8_name"] = "",
-				["armorer_t8_desc"] = "",
+				["armorer_t8_name"] = "Ironclad",
+				["armorer_t8_desc"] = "You gain ##+10%## Damage Resistance when you ##have any amount of Armor##.",
 
-				["armorer_t9_name"] = "",
-				["armorer_t9_desc"] = "",
+				["armorer_t9_name"] = "MK5 Plating",
+				["armorer_t9_desc"] = "Increases your Maximum Armor bonus to ##+100%## and Armor Recovery Rate bonus to ##+25%##.",
 				-- Rogue
 				["rogue_deck"] = "Rogue: CRACKDOWN",
 				["rogue_deck_desc"] = "Provides Dodge Chance and comes with Special Dodges that are guaranteed to avoid certain attacks. Features a rebranded Sneaky Bastard.",

--- a/lua/loc/loc.lua
+++ b/lua/loc/loc.lua
@@ -155,7 +155,94 @@ Hooks:Add("LocalizationManagerPostInit", "DeathVox_Overhaul", function(loc)
 				["rogue_t8_desc"] = "You are ##guaranteed## to Dodge a Taser’s shock attack. This effect has a ##10 second cooldown##.",
 
 				["rogue_t9_name"] = "Smooth Criminal",
-				["rogue_t9_desc"] = "You gain a bonus ##+2%## Dodge Chance for every ##2 points of Detection Risk## under ##35##, up to ##+20%##."
+				["rogue_t9_desc"] = "You gain a bonus ##+2%## Dodge Chance for every ##2 points of Detection Risk## under ##35##, up to ##+20%##.",
+				-- Crook
+				["crook_deck"] = "Crook: CRACKDOWN",
+				["crook_deck_desc"] = "Ballistic Vests and Dodge Chance. Features a rebranded Swan Song.",
+				["crook_t1_name"] = "Extra Padding",
+				["crook_t1_desc"] = "Ballistic Vests gain ##+15## Maximum Armor.",
+
+				["crook_t2_name"] = "Bounce Back",
+				["crook_t2_desc"] = "Ballistic Vests gain ##+20%## Armor Recovery Rate.",
+
+				["crook_t3_name"] = "Vital Protection",
+				["crook_t3_desc"] = "Increases the Maximum Armor bonus for Ballistic Vests to ##+30##.",
+
+				["crook_t4_name"] = "Basic Tailoring",
+				["crook_t4_desc"] = "When wearing a Ballistic Vest, you gain ##+15%## Dodge Chance.",
+
+				["crook_t5_name"] = "Custom Weave",
+				["crook_t5_desc"] = "Increases the Maximum Armor bonus for Ballistic Vests to ##+45##.",
+
+				["crook_t6_name"] = "Keeping Cool",
+				["crook_t6_desc"] = "Increases the Ballistic Vest Armor Recovery Rate bonus to ##+40%##.",
+
+				["crook_t7_name"] = "Prototype Material",
+				["crook_t7_desc"] = "Increases the Maximum Armor bonus for Ballistic Vests to ##+60##.",
+
+				["crook_t8_name"] = "Perfect Fit",
+				["crook_t8_desc"] = "Your Dodge Chance bonus for Ballistic Vests increases to ##+30%##.",
+
+				["crook_t9_name"] = "Borrowed Time",
+				["crook_t9_desc"] = "Instead of being incapacitated when you lose all of your health, you will enter a grace period where you can continue to act for ##4 seconds## before falling. Borrowed Time cannot be triggered by fall damage or fire damage.",
+				-- Hitman
+				["hitman_deck"] = "Hitman: CRACKDOWN",
+				["hitman_deck_desc"] = "Armor Recovery and nothing else. Features a rebranded Messiah.",
+				["hitman_t1_name"] = "Aerodynamic",
+				["hitman_t1_desc"] = "You gain ##+10%## Armor Recovery Rate.",
+
+				["hitman_t2_name"] = "Revolution 909",
+				["hitman_t2_desc"] = "Your Armor will Recover ##2 seconds## after being broken, no matter the situation.",
+
+				["hitman_t3_name"] = "High Fidelity",
+				["hitman_t3_desc"] = "Your Armor Recovery Rate bonus increases to ##+25%##.",
+
+				["hitman_t4_name"] = "Rollin' & Scratchin'",
+				["hitman_t4_desc"] = "Revolution 909’s activation timer is reduced to ##1.75 seconds##.",
+
+				["hitman_t5_name"] = "Fresh",
+				["hitman_t5_desc"] = "Your Armor Recovery Rate bonus increases to ##+45%##.",
+
+				["hitman_t6_name"] = "Steam Machine",
+				["hitman_t6_desc"] = "Revolution 909’s activation timer is reduced to ##1.5 seconds##.",
+
+				["hitman_t7_name"] = "Face to Face",
+				["hitman_t7_desc"] = "Your Armor Recovery Rate bonus increases to ##+70%##.",
+
+				["hitman_t8_name"] = "Human After All",
+				["hitman_t8_desc"] = "Revolution 909’s activation timer is reduced to ##1.25 seconds##.",
+
+				["hitman_t9_name"] = "One More Time",
+				["hitman_t9_desc"] = "You become ##Invulnerable## while in bleedout. While in bleedout, you can Revive yourself by ##killing an enemy and then pressing Jump##. Reviving yourself with One More Time ##consumes an additional Down##."
+				-- Burglar
+				["burglar_deck"] = "Burglar: CRACKDOWN",
+				["burglar_deck_desc"] = "Armor Recovery and nothing else. Features a rebranded Messiah.",
+				["burglar_t1_name"] = "Hands In The Dark",
+				["burglar_t1_desc"] = "You gain ##+5%## Interact Speed while in ##Stealth##.",
+
+				["burglar_t2_name"] = "The Toothpick",
+				["burglar_t2_desc"] = "You gain ##+232## Concealment. No, it's not a typo.",
+
+				["burglar_t3_name"] = "Soft Touch",
+				["burglar_t3_desc"] = "Your Interact Speed bonus increases to ##+10%##.",
+
+				["burglar_t4_name"] = "Ranzer’s Edge",
+				["burglar_t4_desc"] = "You ##no longer take Fall Damage## when falling from Non-Fatal heights. Additionally, the distance you must fall before a fall is considered Fatal is ##doubled##.",
+
+				["burglar_t5_name"] = "Silent Work",
+				["burglar_t5_desc"] = "Your Interact Speed bonus increases to ##+15%##.",
+
+				["burglar_t6_name"] = "Long Haul",
+				["burglar_t6_desc"] = "You bag corpses ##20%## faster and can Sprint while ##carrying heavy Bags##.",
+
+				["burglar_t7_name"] = "Quiet Mind",
+				["burglar_t7_desc"] = "Your Interact Speed bonus increases to ##+20%##.",
+
+				["burglar_t8_name"] = "Fast Talker",
+				["burglar_t8_desc"] = "You answer Pagers ##10%## faster.",
+
+				["burglar_t9_name"] = "Criminal Discretion",
+				["burglar_t9_desc"] = "Your Interact Speed bonus increases to ##+25%##.",
 
 			})
 		end

--- a/lua/loc/loc.lua
+++ b/lua/loc/loc.lua
@@ -39,7 +39,124 @@ Hooks:Add("LocalizationManagerPostInit", "DeathVox_Overhaul", function(loc)
 				["menu_heavy_impact_beta"] = "Money Shot",
 				["menu_heavy_impact_beta_desc"] = "BASIC: ##$basic##\nYour SMGs, and Assault Rifles gain ##+100%## Damage on the last bullet fired from a fully loaded magazine.\n\nACE: ##$pro##\nYour SMGs and Assault Rifles' gain ##+50%## faster Reload Speed when their Magazine is empty.",
 				["menu_far_away_beta"] = "Point Blank",
-				["menu_far_away_beta_desc"] = "BASIC: ##$basic##\nFor the first 100cm, your Shotguns will now gain ##Armor Piercing, Shield Piercing, and Body Piercing.##\n\nACE: ##$pro##\nPoint Blank also grants ##+100%## Damage for the first meter."
+				["menu_far_away_beta_desc"] = "BASIC: ##$basic##\nFor the first 100cm, your Shotguns will now gain ##Armor Piercing, Shield Piercing, and Body Piercing.##\n\nACE: ##$pro##\nPoint Blank also grants ##+100%## Damage for the first meter.",
+				-- Crew Chief
+				["crew_chief_deck"] = "Crew Chief: CRACKDOWN",
+				["crew_chief_deck_desc"] = "A Jack of all trades Team Deck that gives a variety of moderate defensive bonuses. Very referential.",
+				["crew_chief_t1_name"] = "The Usual Suspects",
+				["crew_chief_t1_desc"] = "Your team gains ##+10%## Damage Resistance.",
+
+				["crew_chief_t2_name"] = "Reservoir Dogs",
+				["crew_chief_t2_desc"] = "Your team gains ##+15%## Maximum Health.",
+
+				["crew_chief_t3_name"] = "One Hundred Steps",
+				["crew_chief_t3_desc"] = "Your team gains ##+100%## Maximum Stamina.",
+
+				["crew_chief_t4_name"] = "State of Grace",
+				["crew_chief_t4_desc"] = "Your team gains ##+10%## Maximum Armor.",
+
+				["crew_chief_t5_name"] = "Mean Streets",
+				["crew_chief_t5_desc"] = "Each member of your team regenerates ##1%## of their Missing Health per second.",
+
+				["crew_chief_t6_name"] = "Goodfellas",
+				["crew_chief_t6_desc"] = "Increases your team’s Maximum Health bonus to ##+30%##.",
+
+				["crew_chief_t7_name"] = "Heat",
+				["crew_chief_t7_desc"] = "Your team gains ##+10%## Armor Recovery Rate.",
+
+				["crew_chief_t8_name"] = "Layer Cake",
+				["crew_chief_t8_desc"] = "Increases your team’s Maximum Armor bonus to ##+20%##.",
+
+				["crew_chief_t9_name"] = "Angels with Dirty Faces",
+				["crew_chief_t9_desc"] = "Your team gains an additional ##10%## Damage Resistance, for a maximum of ##+20%##.",
+				-- Muscle
+				["muscle_deck"] = "Muscle: CRACKDOWN",
+				["muscle_deck_desc"] = "Massive Health and Health Regeneration. Flex eternal!",
+				["muscle_t1_name"] = "",
+				["muscle_t1_desc"] = "",
+
+				["muscle_t2_name"] = "",
+				["muscle_t2_desc"] = "",
+
+				["muscle_t3_name"] = "",
+				["muscle_t3_desc"] = "",
+
+				["muscle_t4_name"] = "",
+				["muscle_t4_desc"] = "",
+
+				["muscle_t5_name"] = "",
+				["muscle_t5_desc"] = "",
+
+				["muscle_t6_name"] = "",
+				["muscle_t6_desc"] = "",
+
+				["muscle_t7_name"] = "",
+				["muscle_t7_desc"] = "",
+
+				["muscle_t8_name"] = "",
+				["muscle_t8_desc"] = "",
+
+				["muscle_t9_name"] = "",
+				["muscle_t9_desc"] = "",
+				-- Armorer
+				["armorer_deck"] = "Armorer: CRACKDOWN",
+				["armorer_deck_desc"] = "Heavy Armor all day, every day.",
+				["armorer_t1_name"] = "",
+				["armorer_t1_desc"] = "",
+
+				["armorer_t2_name"] = "",
+				["armorer_t2_desc"] = "",
+
+				["armorer_t3_name"] = "",
+				["armorer_t3_desc"] = "",
+
+				["armorer_t4_name"] = "",
+				["armorer_t4_desc"] = "",
+
+				["armorer_t5_name"] = "",
+				["armorer_t5_desc"] = "",
+
+				["armorer_t6_name"] = "",
+				["armorer_t6_desc"] = "",
+
+				["armorer_t7_name"] = "",
+				["armorer_t7_desc"] = "",
+
+				["armorer_t8_name"] = "",
+				["armorer_t8_desc"] = "",
+
+				["armorer_t9_name"] = "",
+				["armorer_t9_desc"] = "",
+				-- Rogue
+				["rogue_deck"] = "Rogue: CRACKDOWN",
+				["rogue_deck_desc"] = "Provides Dodge Chance and comes with Special Dodges that are guaranteed to avoid certain attacks. Features a rebranded Sneaky Bastard.",
+				["rogue_t1_name"] = "",
+				["rogue_t1_desc"] = "",
+
+				["rogue_t2_name"] = "",
+				["rogue_t2_desc"] = "",
+
+				["rogue_t3_name"] = "",
+				["rogue_t3_desc"] = "",
+
+				["rogue_t4_name"] = "",
+				["rogue_t4_desc"] = "",
+
+				["rogue_t5_name"] = "",
+				["rogue_t5_desc"] = "",
+
+				["rogue_t6_name"] = "",
+				["rogue_t6_desc"] = "",
+
+				["rogue_t7_name"] = "",
+				["rogue_t7_desc"] = "",
+
+				["rogue_t8_name"] = "",
+				["rogue_t8_desc"] = "",
+
+				["rogue_t9_name"] = "",
+				["rogue_t9_desc"] = ""
+
 			})
 		end
 		loc:add_localized_strings({


### PR DESCRIPTION
Lets you easily set a weapon's stats with the exact numbers off the google doc instead of having to do a bunch of math and manually filling out all the data.

Perk decks complete:

- [x] Crew Chief
- [x] Muscle
- [x] Armorer
- [x] Rogue
- [x] Crook
- [x] Hitman
- [x] Burglar
- [ ] Infiltrator
- [ ] Sociopath
- [ ] Gambler
- [ ] Grinder
- [ ] Yakuza
- [ ] Ex-President
- [ ] Maniac
- [ ] Anarchist
- [ ] Biker
- [ ] Sicario
- [ ] Stoic
- [ ] Tag Team
- [ ] Hacker